### PR TITLE
bugfix - angular not bootstrapping correctly on cordova.

### DIFF
--- a/urigo:angular.js
+++ b/urigo:angular.js
@@ -23,8 +23,7 @@ angularMeteor.config(['$interpolateProvider',
   }
 ]);
 
-// Manual initialisation of angular-meteor
-angular.element(document).ready(function () {
+var onReady = function () {
   if (!angular.element(document).injector()) {
     angular.bootstrap(document, ['angular-meteor']);
   }
@@ -44,4 +43,12 @@ angular.element(document).ready(function () {
       });
     }
   }
-});
+};
+
+// Manual initialisation of angular-meteor
+if (Meteor.isCordova) {
+  angular.element(document).on("deviceready", onReady);
+}
+else {
+  angular.element(document).ready(onReady);
+}

--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "dependencies": [
     [
       "meteor",
-      "1.0.2"
+      "1.1.2"
     ],
     [
       "mquandalle:bower",
@@ -10,7 +10,7 @@
     ],
     [
       "underscore",
-      "1.0.0"
+      "1.0.1"
     ]
   ],
   "pluginDependencies": [],


### PR DESCRIPTION
fixes an issue with angular not bootstrapping on cordova because `document.ready` is fired before the html is loaded. Instead using the `deviceready` event...
