### PR TITLE
Compile meteorInclude template after DOM insertion

### DIFF
--- a/modules/angular-meteor-template.js
+++ b/modules/angular-meteor-template.js
@@ -82,6 +82,7 @@ angularMeteorTemplate.directive('meteorInclude', [
         if (name && Template[name]) {
           var template = Template[name];
           Blaze.renderWithData(template, scope, element.get(0));
+          $compile(element.contents())(scope);
         } else {
           console.error("meteorTemplate: There is no template with the name '" + name + "'");
         }


### PR DESCRIPTION
In order to process directives in the included template, run it through `$compile`.
