### PR TITLE
fix phase check in isolated scopes

### DIFF
--- a/modules/angular-meteor-collections.js
+++ b/modules/angular-meteor-collections.js
@@ -13,7 +13,7 @@ angularMeteorCollections.factory('$collection', ['$q', 'HashKeyCopier', '$subscr
         bindOne: function(scope, model, id, auto, publisher) {
           Tracker.autorun(function(self) {
             scope[model] = collection.findOne(id);
-            if (!scope.$$phase) scope.$apply(); // Update bindings in scope.
+            if (!scope.$root.$$phase) scope.$apply(); // Update bindings in scope.
             scope.$on('$destroy', function () {
               self.stop(); // Stop computation if scope is destroyed.
             });
@@ -72,7 +72,7 @@ angularMeteorCollections.factory('$collection', ['$q', 'HashKeyCopier', '$subscr
               var newArray = HashKeyCopier.copyHashKeys(scope[model], ngCollection, ["_id"]);
               scope[model] = updateAngularCollection(newArray, scope[model]);
 
-              if (!scope.$$phase) scope.$apply(); // Update bindings in scope.
+              if (!scope.$root.$$phase) scope.$apply(); // Update bindings in scope.
               scope.$on('$destroy', function () {
                 self.stop(); // Stop computation if scope is destroyed.
               });


### PR DESCRIPTION
Hi, 
isolated scopes don't inherit $$phase property. That's why I'm getting "[$rootScope:inprog] $digest already in progress" errors when applying $collection.bind() to isolated scope. I fixed this by refering to scope.$root wchich is always available.
