### PR TITLE
Use options on findOne of bindOne

### DIFF
--- a/modules/angular-meteor-collections.js
+++ b/modules/angular-meteor-collections.js
@@ -12,7 +12,7 @@ angularMeteorCollections.factory('$collection', ['$q', 'HashKeyCopier', '$subscr
 
         bindOne: function(scope, model, id, auto, publisher) {
           Tracker.autorun(function(self) {
-            scope[model] = collection.findOne(id);
+            scope[model] = collection.findOne(id, options);
             if (!scope.$root.$$phase) scope.$apply(); // Update bindings in scope.
             scope.$on('$destroy', function () {
               self.stop(); // Stop computation if scope is destroyed.


### PR DESCRIPTION
If you want to pass ```options```, then your ```bindOne``` will look like ```$collection(Todos, null, { fields: { content: 1 } }).bindOne($scope, 'model', criteria)```.

I tested that if ```options``` is ```undefined``` the ```findOne``` will still work.