### PR TITLE
Fixed: dependency problem in angular-meteor.collections

### DIFF
--- a/modules/angular-meteor-collections.js
+++ b/modules/angular-meteor-collections.js
@@ -1,5 +1,5 @@
 'use strict';
-var angularMeteorCollections = angular.module('angular-meteor.collections', ['angular-meteor.subscribe']);
+var angularMeteorCollections = angular.module('angular-meteor.collections', ['angular-meteor.subscribe', 'hashKeyCopier']);
 
 var AngularMeteorCollection = function (collection, $q, selector, options) {
   var self = collection.find(selector, options).fetch();


### PR DESCRIPTION
Hey @Urigo, The 'angular-meteor.collections' module has a dependency on the 'hashKeyCopier' module. See: line 148. 
If you work with this module independently, Angular.js throws an exception.

Thanks!

Yago