### PR TITLE
Convert Windows style paths to *nix style in build step

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -10,7 +10,7 @@ Plugin.registerSourceHandler('tpl', {
   var contents = compileStep.read().toString('utf8');
 
   var results = 'angular.module(\'angular-meteor\').run([\'$templateCache\', function($templateCache) {' +
-    '$templateCache.put(\'' + compileStep.inputPath + '\', \'' +
+    '$templateCache.put(\'' + compileStep.inputPath.replace(/\\/g, "/") + '\', \'' +
       minify(contents.replace(/'/g, "\\'"), {
         collapseWhitespace : true,
         removeComments : true,


### PR DESCRIPTION
As discussed in #169, we need to normalize paths across platforms to be able to consistently refer to templates in apps.

There might come a [standardized solution](https://github.com/meteor/windows-preview/issues/47), but this is so simple, it could be used in the meantime.