### PR TITLE
Added currentUserPromise to the $rootScope

### DIFF
--- a/.docs/angular-meteor/client/views/api/api.user.html
+++ b/.docs/angular-meteor/client/views/api/api.user.html
@@ -10,7 +10,7 @@
 
 # User
 
-Two [$rootScope](https://docs.angularjs.org/api/ng/service/$rootScope) variables to support [Meteor.user](http://docs.meteor.com/#/full/meteor_user) when working with [Meteor's accounts package](http://docs.meteor.com/#/full/accounts_api)
+Three [$rootScope](https://docs.angularjs.org/api/ng/service/$rootScope) variables to support [Meteor.user](http://docs.meteor.com/#/full/meteor_user) when working with [Meteor's accounts package](http://docs.meteor.com/#/full/accounts_api)
 
 ----
 
@@ -20,17 +20,22 @@ Two [$rootScope](https://docs.angularjs.org/api/ng/service/$rootScope) variables
 
     $rootScope.loggingIn
 
+    $rootScope.currentUserPromise
+
 ## Variables
 
 <table class="variables-matrix return-arguments">
 <tbody><tr>
   <td><a href="" class="label type-hint type-hint-expression">$rootScope</a></td>
   <td><p>Adding to $rootScope support for Meteor's <a href="http://docs.meteor.com/#/full/template_currentuser">currentUser</a>
-         and <a href="http://docs.meteor.com/#/full/template_loggingin">loggingin</a>
+         and <a href="http://docs.meteor.com/#/full/template_loggingin">loggingIn</a>
   </p>
     <ul>
       <li><code><span class="pln">$rootScope.currentUser</span></code> — The current logged in user and it's data. it is undefined if the user is not logged in</li>
       <li><code><span class="pln">$rootScope.loggingIn</span></code> — True if a login method (such as Meteor.loginWithPassword, Meteor.loginWithFacebook, or Accounts.createUser) is currently in progress</li>
+      <li><code><span class="pln">$rootScope.currentUserPromise</span></code> —
+          A promise that is resolved with the <a href="http://docs.meteor.com/#/full/meteor_user">currentUser</a> when the user subscription is ready.
+          You can wait on it in your route provider's <strong>resolve</strong> config to make sure the <a href="http://docs.meteor.com/#/full/meteor_user">currentUser</a> is not still <i>undefined</i> when you need it in your controllers.</li>
     </ul>
   </td>
 </tr>
@@ -45,6 +50,17 @@ Two [$rootScope](https://docs.angularjs.org/api/ng/service/$rootScope) variables
 
     // In controllers
     if ($rootScope.currentUser)
+
+    // In route config ('ui-router' in the example, but works with 'ngRoute' the same way)
+    $stateProvider
+        .state('home', {
+            url: '/',
+            templateUrl: 'client/views/home.tpl',
+            controller: 'HomeController'
+            resolve: {
+                currentUserNonReactive: $rootScope.currentUserPromise
+            }
+        });
 
         {{/markdown}}
     </do-nothing>

--- a/modules/angular-meteor-user.js
+++ b/modules/angular-meteor-user.js
@@ -1,10 +1,23 @@
 var angularMeteorUser = angular.module('angular-meteor.user', ['angular-meteor.utils']);
 
 angularMeteorUser.run(['$rootScope', '$meteorUtils', function($rootScope, $meteorUtils){
+  var currentUserDefer;
+
   $meteorUtils.autorun($rootScope, function(){
     if (Meteor.user) {
       $rootScope.currentUser = Meteor.user();
       $rootScope.loggingIn = Meteor.loggingIn();
     }
+
+    // if there is no currentUserDefer (on first autorun)
+    // or it is already resolved, but the Meteor.user() is changing
+    if (!currentUserDefer || Meteor.loggingIn() ) {
+      currentUserDefer = $q.defer();
+      $rootScope.currentUserPromise = currentUserDefer.promise;
+    }
+    if ( !Meteor.loggingIn() ) {
+      currentUserDefer.resolve( Meteor.user() );
+    }
+
   });
 }]);


### PR DESCRIPTION
issue #181
@Urigo, this is my first pull request, so please review my changes. Now it should be sufficient to just set in your route config:
```javascript
$stateProvider
    .state('home', {
        url: '/',
        templateUrl: 'client/views/home.tpl',
        controller: 'HomeController'
        resolve: {
            currentUser: $rootScope.currentUserPromise
        }
    });
```
Or if you don't want to hide the reactive $rootScope.currentUser in yout controller's scope, just assign it to another property:
```javascript
$stateProvider
    .state('home', {
        url: '/',
        templateUrl: 'client/views/home.tpl',
        controller: 'HomeController'
        resolve: {
            currentUserNonReactive: $rootScope.currentUserPromise
        }
    });
```
It is also a good idea to maybe add the currentUserPromise to the unit tests.