### PR TITLE
Maintain a single whitespace between elements in compiled templates

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -18,6 +18,7 @@ Plugin.registerSourceHandler('ng.html', {
     '$templateCache.put(\'' + compileStep.inputPath.replace(/\\/g, "/") + '\', \'' +
       minify(contents.replace(/'/g, "\\'"), {
         collapseWhitespace : true,
+        conservativeCollapse: true,
         removeComments : true,
         minifyJS : true,
         minifyCSS: true,


### PR DESCRIPTION
Removing all whitespace in templates (as is being done currently) can have side effects for how the content is presented when it comes to inline elements, eg.
```html
<p>My name is <em>Fredrik</em></p>
```
is compiled into
```html
<p>My name is<em>Fredrik</em></p>
```

Even though this does increase the filesize slightly, I think it definitely is expected behavior for this kind of inline space to be preserved all the way in to the browser.