### PR TITLE
Preserve comments in minified templates

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -18,10 +18,9 @@ Plugin.registerSourceHandler('ng.html', {
     '$templateCache.put(\'' + compileStep.inputPath.replace(/\\/g, "/") + '\', \'' +
       minify(contents.replace(/'/g, "\\'"), {
         collapseWhitespace : true,
-        conservativeCollapse: true,
-        removeComments : true,
+        conservativeCollapse : true,
         minifyJS : true,
-        minifyCSS: true,
+        minifyCSS : true,
         processScripts : ['text/ng-template']
       }) + '\');' +
     '}]);';


### PR DESCRIPTION
Angular directives can be included with [HTML comments](https://docs.angularjs.org/guide/directive#directive-types), so we want to preserve those in the minified templates.