### PR TITLE
feat(plugin): support for ng-annotate, process .ng.js files

### DIFF
--- a/.npm/plugin/ngAnnotate/.gitignore
+++ b/.npm/plugin/ngAnnotate/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/plugin/ngAnnotate/README
+++ b/.npm/plugin/ngAnnotate/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/plugin/ngAnnotate/npm-shrinkwrap.json
+++ b/.npm/plugin/ngAnnotate/npm-shrinkwrap.json
@@ -1,0 +1,63 @@
+{
+  "dependencies": {
+    "ng-annotate": {
+      "version": "0.15.4",
+      "dependencies": {
+        "acorn": {
+          "version": "0.11.0"
+        },
+        "alter": {
+          "version": "0.2.0"
+        },
+        "convert-source-map": {
+          "version": "0.4.1"
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2"
+            },
+            "minimist": {
+              "version": "0.0.10"
+            }
+          }
+        },
+        "ordered-ast-traverse": {
+          "version": "1.1.1",
+          "dependencies": {
+            "ordered-esprima-props": {
+              "version": "1.1.0"
+            }
+          }
+        },
+        "simple-fmt": {
+          "version": "0.1.0"
+        },
+        "simple-is": {
+          "version": "0.2.0"
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0"
+            }
+          }
+        },
+        "stable": {
+          "version": "0.1.5"
+        },
+        "stringmap": {
+          "version": "0.2.2"
+        },
+        "stringset": {
+          "version": "0.2.1"
+        },
+        "tryor": {
+          "version": "0.1.2"
+        }
+      }
+    }
+  }
+}

--- a/package.js
+++ b/package.js
@@ -15,6 +15,16 @@ Package.registerBuildPlugin({
   }
 });
 
+Package.registerBuildPlugin({
+  name: 'ngAnnotate',
+  sources: [
+    'plugin/annotate.js'
+  ],
+  npmDependencies: {
+    'ng-annotate': '0.15.4'
+  }
+});
+
 Package.on_use(function (api) {
   api.versionsFrom('METEOR@0.9.0.1');
 

--- a/plugin/annotate.js
+++ b/plugin/annotate.js
@@ -1,0 +1,18 @@
+
+var ngAnnotate = Npm.require('ng-annotate');
+
+Plugin.registerSourceHandler('ng.js', {
+  isTemplate: true,
+  archMatching: 'web'
+}, function(compileStep) {
+
+  var ret = ngAnnotate(compileStep.read().toString('utf8'), {
+    add: true
+  });
+
+  compileStep.addJavaScript({
+    path : compileStep.inputPath,
+    data : ret.src,
+    sourcePath : compileStep.inputPath
+  });
+});


### PR DESCRIPTION
I know it's being discussed at https://github.com/Urigo/angular-meteor/issues/109 and https://github.com/meteor/meteor/issues/3508 but it looks like we have to wait until they find a way to process the original .js files.

So hence my PR as a suggestion: why for now not register `ng.js` to be processable by ng-annotate? It would make my project a lot easier to work with.

In addition, we could do more processing on this extension such as https://github.com/werk85/grunt-ng-constant.