### PR TITLE
Fix problem with multi-line comments breaking compileAngularTemplates step due to invalid JS generated for the template

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -15,14 +15,14 @@ Plugin.registerSourceHandler('ng.html', {
     // Ticket here: https://github.com/Urigo/angular-meteor/issues/169
     // A standardized solution to this problem might be on its way, see this ticket:
     // https://github.com/meteor/windows-preview/issues/47
-    '$templateCache.put(\'' + compileStep.inputPath.replace(/\\/g, "/") + '\', \'' +
-      minify(contents.replace(/'/g, "\\'"), {
+    '$templateCache.put(' + JSON.stringify(compileStep.inputPath.replace(/\\/g, "/")) + ', ' +
+      JSON.stringify(minify(contents, {
         collapseWhitespace : true,
         conservativeCollapse : true,
         minifyJS : true,
         minifyCSS : true,
         processScripts : ['text/ng-template']
-      }) + '\');' +
+      })) + ');' +
     '}]);';
 
   compileStep.addJavaScript({


### PR DESCRIPTION
The issue was introduced in a47ecc2. When a ng.html file contains multi-line comments Meteor failed on the console with error like "Unexpected token ILLEGAL" due to the generated JS that adds the html to the template cache was broken.
For example this could break your app:
```
<div>
<!--
  <div>
      Containing comments on multiple lines breaks the build
  </div>
-->
</div>
```
In order to properly fix that - the best future proof approach is to JSON.stringify the strings as this ensures any JS special character is properly escaped and turned into string literal.

@Urigo - this is real big issue with the latest version v0.8.0, so please act quickly