### PR TITLE
fix(annotate): check for errors before attempting to add annotated scrip...

### DIFF
--- a/plugin/annotate.js
+++ b/plugin/annotate.js
@@ -10,9 +10,15 @@ Plugin.registerSourceHandler('ng.js', {
     add: true
   });
 
-  compileStep.addJavaScript({
-    path : compileStep.inputPath,
-    data : ret.src,
-    sourcePath : compileStep.inputPath
-  });
+  if (ret.errors) {
+    throw new Error(ret.errors.join(': '));
+  }
+  else {
+    compileStep.addJavaScript({
+      path : compileStep.inputPath,
+      data : ret.src,
+      sourcePath : compileStep.inputPath
+    });
+  }
+
 });


### PR DESCRIPTION
...ts

Thanks to @olov, see https://github.com/nickjanssen/angular-meteor/commit/29d4cf88894598db930e912ded6c3f0b8a88a5f0#commitcomment-10406291

When the annotator fails, it will now throw an error with helpful information:
```
=> Errors prevented startup:                  
   
   While building the application:
   packages/ngAnnotate/plugin/annotate.js:14:1: error: couldn't process source due to
   parse error: Unexpected token (19:2) (compiling client/router.ng.js) (at Package)
   
=> Your application has errors. Waiting for file change.
```

Instead of

```
=> Errors prevented startup:                  
   
   While building the application:

   /Users/nickjanssen/.meteor/packages/meteor-tool/.1.1.1.gi7rkz++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/tools/compiler.js:704:17:
   'data' option to addJavaScript must be a string (compiling client/router.ng.js)
   at Object.compileStep.addJavaScript
   (/Users/nickjanssen/.meteor/packages/meteor-tool/.1.1.1.gi7rkz++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/tools/compiler.js:704:17)
   at Package (packages/ngAnnotate/plugin/annotate.js:13:1)
```