### PR TITLE
add pbastowski:angular-babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ The following is a non-exhaustive list of Meteor packages common Angular librari
 - [netanelgilad:text-angular](https://github.com/netanelgilad/meteor-textAngular/) empowers angular-meteor with [textAngular](https://github.com/fraywing/textAngular) module.
 - [tonekk:angular-moment](https://github.com/tonekk/meteor-angular-moment) empowers angular-meteor with [angularMoment](https://github.com/urish/angular-moment) module.
 - [civilframe:angular-jade](https://github.com/civilframe/meteor-angular-jade) enables the usage of JADE files in place of HTML files. Files ending in *.ng.jade and will be compiled to *.html.
+- [pbastowski:angular-babel](https://github.com/pbastowski/angular-meteor-babel/) empowers angular-meteor with Babel and ng-annotate all in the one package. Files ending in .es6 will first be transpiled by Babel and then annotated with ng-annotate.
 
 Feel free to make more Angular packages and add them to that list as well.
 


### PR DESCRIPTION
Added a reference in README to the new package pbastowski:angular-babel. JavaScript files ending in .es6 will first be transpiled by Babel and then annotated with ng-annotate. Without this package angular-meteor will only ng-annotate files that end in .ng.js.