### PR TITLE
Fix #258 - Add compileStep.packageName to templateCache key

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -12,13 +12,17 @@ Plugin.registerSourceHandler('ng.html', {
   // Just parse the html to make sure it is correct before minifying
   HTMLTools.parseFragment(contents);
 
+  // Build the templateCache prefix using the package name
+  var packagePrefix = compileStep.packageName;
+  packagePrefix = packagePrefix ? (packagePrefix.replace(/:/g, '_') + '_') : '';
+
   var results = 'angular.module(\'angular-meteor\').run([\'$templateCache\', function($templateCache) {' +
     // Since compileStep.inputPath uses backslashes on Windows, we need replace them
     // with forward slashes to be able to consistently include templates across platforms.
     // Ticket here: https://github.com/Urigo/angular-meteor/issues/169
     // A standardized solution to this problem might be on its way, see this ticket:
     // https://github.com/meteor/windows-preview/issues/47
-    '$templateCache.put(' + JSON.stringify(compileStep.inputPath.replace(/\\/g, "/")) + ', ' +
+    '$templateCache.put(' + JSON.stringify(packagePrefix + compileStep.inputPath.replace(/\\/g, "/")) + ', ' +
       JSON.stringify(minify(contents, {
         collapseWhitespace : true,
         conservativeCollapse : true,


### PR DESCRIPTION
***BREAKING CHANGE*** templateUrl paths for *.ng.html files inside meteor packages have been changed.

angular-meteor now prefixes the package name when adding templates to $templateCache. The colon in the package name is replaced with an underscore and the package name is separated from the template name with an underscore. So, if you have a package named my-app:my-package with a template at packages/my-app:my-template/client/views/my-template.ng.html, the templateUrl you use in the route should be:

    my-app_my-package_client/views/my-template.ng.html