### PR TITLE
object check in $$hashKey deletion in nested values

### DIFF
--- a/modules/angular-meteor-meteorCollection.js
+++ b/modules/angular-meteor-meteorCollection.js
@@ -33,7 +33,7 @@ angularMeteorCollections.factory('AngularMeteorCollection', ['$q', '$meteorSubsc
           delete item.$$hashKey;
 
         angular.forEach(item, function(prop) {
-          if (prop.$$hashKey)
+          if (_.isObject(prop) && prop.$$hashKey)
             delete prop.$$hashKey;
         });
 


### PR DESCRIPTION
Hi, I had and object that contained a null value like this:
```
myCollection.save({foo: null})
```
which produced an error at ```delete prop.$$hashKey```