### PR TITLE
$scope.$meteorAutorun wrapper to simplify usage

### DIFF
--- a/modules/angular-meteor-utils.js
+++ b/modules/angular-meteor-utils.js
@@ -27,3 +27,10 @@ angularMeteorUtils.service('$meteorUtils', [
       return comp;
     };
   }]);
+
+angularMeteorUtils.run(['$rootScope', '$meteorUtils',
+  function($rootScope, $meteorUtils) {
+    Object.getPrototypeOf($rootScope).$meteorAutorun = function(fn) {
+      return $meteorUtils.autorun(this, fn);
+    };
+}]);


### PR DESCRIPTION
This is a very small change, it's just a wrapper of $meteor.autorun to be available as $scope.$meteorAutorun. This will allow to change this:
```javascript
// ....
.controller('MyController', ['$scope', '$meteor', function($scope, $meteor) {
  $meteor.autorun($scope, function() {
    // ......
  });
}]);
```
for this:
```javascript
// ....
.controller('MyController', ['$scope', function($scope) {
  $scope.$meteorAutorun(function() {
    // ...
  });
}]);
```
Before continuing on the PR to add docs, I would like to hear opinions on this. Should we continue to add $meteor stuff to $rootScope? Is it a good idea to have these methods always available?

$scope.$meteorSubscribe, $scope.$meteorCollection, & $scope.$meteorObject are wrappers that add extra functionality that depends on $scope ($on('$destroy')), but this other method would be a very minor enhacement (though the footprint is minimal).

Also, I've noticed that anytime I inject $meteor on a controller it also has a $scope injection, and I'm getting lazy of always having to inject both of them, so I'm thinking on having this:
```javascript
// ...
.run(['$rootScope', '$meteor', function($rootScope, $meteor) {
  Object.getPrototypeOf($rootScope).$meteor = $meteor;
}]);
```
I'm not sure if it's a good idea or if it would generate more load than the one it would remove. Any suggestions?