### PR TITLE
Adjusting logic to return Date objects

### DIFF
--- a/modules/angular-meteor-utils.js
+++ b/modules/angular-meteor-utils.js
@@ -25,7 +25,7 @@ angularMeteorUtils.service('$meteorUtils', [ '$timeout',
     };
     // Borrowed from angularFire - https://github.com/firebase/angularfire/blob/master/src/utils.js#L445-L454
     this.stripDollarPrefixedKeys = function (data) {
-      if( !angular.isObject(data) || data instanceof File) { return data; }
+      if( !angular.isObject(data) || data instanceof File || data instanceof Date) { return data; }
       var out = angular.isArray(data)? [] : {};
       angular.forEach(data, function(v,k) {
         if(typeof k !== 'string' || k.charAt(0) !== '$') {


### PR DESCRIPTION
I made an adjustment to the stripDollarPrefixedKeys so that Date objects are returned instead of being destroyed during parsing. I ran into this problem while working with Simple Schema and a standard Date field. I don't believe this simple change will have any negative effects.

If I've missed any protocols or anything for submitting this change let me know.

Thanks!
Chris