### PR TITLE
Escape {{ }} in camera example

### DIFF
--- a/.docs/angular-meteor/client/views/api/api.camera.html
+++ b/.docs/angular-meteor/client/views/api/api.camera.html
@@ -81,7 +81,7 @@ Must add [mdg:camera package](https://atmospherejs.com/mdg/camera) to use!
 
         <div ng-controller="cameraCtrl">
           <button ng-click="takePicture()">Picture</button>
-          <img ng-src="{{party.imageData}}">
+          <img ng-src="~{{party.imageData~}}'">
         </div>
 
       {{/markdown}}


### PR DESCRIPTION
I am not sure how to actually escape `{{party.imageData}}`. It is in the source code, but as the code is being processed, `{{party.imageData}}` does not appear in the [camera API docs](http://angular-meteor.com/api/camera). Please propose fix.
I noticed it because the example did not work for me. Then I looked it up in the video of Urigo and saw the curly braces.