### PR TITLE
Cfs file insert fix

### DIFF
--- a/modules/angular-meteor-meteorCollection.js
+++ b/modules/angular-meteor-meteorCollection.js
@@ -30,8 +30,7 @@ angularMeteorCollections.factory('AngularMeteorCollection', ['$q', '$meteorSubsc
         var deferred = $q.defer();
 
         // delete $$hashkey
-        if (!(item instanceof File))
-          item = $meteorUtils.stripDollarPrefixedKeys(item);
+        item = $meteorUtils.stripDollarPrefixedKeys(item);
 
         if (item._id) { // Performs an update if the _id property is set.
           var item_id = item._id; // Store the _id in temporary variable

--- a/modules/angular-meteor-utils.js
+++ b/modules/angular-meteor-utils.js
@@ -25,7 +25,7 @@ angularMeteorUtils.service('$meteorUtils', [ '$timeout',
     };
     // Borrowed from angularFire - https://github.com/firebase/angularfire/blob/master/src/utils.js#L445-L454
     this.stripDollarPrefixedKeys = function (data) {
-      if( !angular.isObject(data) || data instanceof File || data instanceof Date) { return data; }
+      if( !angular.isObject(data) || data instanceof File || (typeof FS === 'object' && data instanceof FS.File) || data instanceof Date) { return data; }
       var out = angular.isArray(data)? [] : {};
       angular.forEach(data, function(v,k) {
         if(typeof k !== 'string' || k.charAt(0) !== '$') {
@@ -33,7 +33,7 @@ angularMeteorUtils.service('$meteorUtils', [ '$timeout',
         }
       });
       return out;
-    }
+    };
   }]);
 
 angularMeteorUtils.run(['$rootScope', '$meteorUtils',

--- a/tests/integration/angular-meteor-utils-spec.js
+++ b/tests/integration/angular-meteor-utils-spec.js
@@ -82,9 +82,9 @@ describe('$meteorUtils service', function () {
     });
     it('should ignore FS.File instances', function(){
 
-      var cfsExits = typeof FS === 'object';
+      var cfsExits = typeof window.FS === 'object';
       if(!cfsExits){
-        FS = {
+        window.FS = {
           File : function(){}
         };
       }
@@ -93,9 +93,25 @@ describe('$meteorUtils service', function () {
       var result = $meteorUtils.stripDollarPrefixedKeys(fsFile);
 
       if(!cfsExits){ // clean up
-        delete FS;
+        delete window.FS;
       }
-      expect(result).toBe(result);
+      expect(result).toBe(fsFile);
+
+    });
+    it('should ignore Date instances', function(){
+
+      var input = new Date();
+      var result = $meteorUtils.stripDollarPrefixedKeys(input);
+
+      expect(result).toBe(input);
+
+    });
+    it('should ignore File instances', function(){
+
+      var input = new File([], "myfile.jpg");
+      var result = $meteorUtils.stripDollarPrefixedKeys(input);
+
+      expect(result).toBe(input);
 
     });
   });

--- a/tests/integration/angular-meteor-utils-spec.js
+++ b/tests/integration/angular-meteor-utils-spec.js
@@ -70,4 +70,33 @@ describe('$meteorUtils service', function () {
       expect(handle.stop).toHaveBeenCalled();
     });
   });
+  describe('stripDollarPrefixedKeys', function () {
+
+    it('should remove keys with $ prefix', function(){
+
+      var result = $meteorUtils.stripDollarPrefixedKeys({'$foo': 1, '$$baz': 3, bar : 2});
+      expect(result.hasOwnProperty('$foo')).toBe(false);
+      expect(result.hasOwnProperty('$$baz')).toBe(false);
+      expect(result.bar).toEqual(2);
+
+    });
+    it('should ignore FS.File instances', function(){
+
+      var cfsExits = typeof FS === 'object';
+      if(!cfsExits){
+        FS = {
+          File : function(){}
+        };
+      }
+
+      var fsFile = new FS.File();
+      var result = $meteorUtils.stripDollarPrefixedKeys(fsFile);
+
+      if(!cfsExits){ // clean up
+        delete FS;
+      }
+      expect(result).toBe(result);
+
+    });
+  });
 });


### PR DESCRIPTION
A common use case is that you insert FS.File instances in a cfs collection, the strip hash key function ignored this case and returns a object. This results in an error if you do something like
```
var fsFile = new FS.File(file)
fsFile.ownerId = Meteor.userId();
MyCollectionFS.insert(fsFile);
```

I added the handling of FS.File to the strip function