### PR TITLE
Fix cancel button syntax problem.

### DIFF
--- a/.docs/angular-meteor/client/views/steps/tutorial.step_06.html
+++ b/.docs/angular-meteor/client/views/steps/tutorial.step_06.html
@@ -82,7 +82,7 @@ __party-details.ng.html__
 
     <button ng-click="save()">Save</button>
     <button ng-click="reset()">Reset form</button>
-    <button><a href="/parties">Cancel</a></button>
+    <button onclick="window.location.href='/parties'">Cancel</button>
 
 
 

--- a/.docs/angular-meteor/client/views/steps/tutorial.step_06.html
+++ b/.docs/angular-meteor/client/views/steps/tutorial.step_06.html
@@ -82,7 +82,7 @@ __party-details.ng.html__
 
     <button ng-click="save()">Save</button>
     <button ng-click="reset()">Reset form</button>
-    <button onclick="window.location.href='/parties'">Cancel</button>
+    <button ui-sref="parties">Cancel</button>
 
 
 


### PR DESCRIPTION
Buttons should not contain any interactive descendants.
"<button><a href="/parties">Cancel</a></button>" is invalid in HTML5.
This doesn't work in Firefox 38.

Reference: https://stackoverflow.com/questions/2906582/how-to-create-an-html-button-that-acts-like-a-link