### PR TITLE
Fix meteorCollection bad behavior with deep-objects update and null fields

### DIFF
--- a/lib/diff-array.js
+++ b/lib/diff-array.js
@@ -225,7 +225,8 @@ var handleDeepProperties = function(object, paths, cb) {
     var currentObject = object;
 
     for (var i = 0; i < props.length - 1; i++) {
-      if (!_.isObject(currentObject[props[i]]))
+      var tmp = currentObject[props[i]];
+      if (!_.isObject(tmp) || _.isArray(tmp))
         currentObject[props[i]] = {};
       currentObject = currentObject[props[i]];
     }

--- a/lib/diff-array.js
+++ b/lib/diff-array.js
@@ -137,46 +137,40 @@ var isActualObject = function (value) {
 var diffObjectChanges = function (oldItem, newItem, preventNestedDiff) {
   var result = {};
 
-  if (_.isUndefined(oldItem)) {
-    result = EJSON.clone(newItem)
+  angular.forEach(newItem, function (value, key) {
+    var oldValue;
 
-  } else {
+    if (oldItem && typeof oldItem === 'object')
+      oldValue = oldItem[key];
 
-    angular.forEach(newItem, function (value, key) {
-      var oldValue;
+    if (oldItem && angular.equals(value, oldValue))
+      return;
 
-      if (oldItem && typeof oldItem === 'object')
-        oldValue = oldItem[key];
+    if (key == '$$hashKey')
+      return;
 
-      if (oldItem && angular.equals(value, oldValue))
-        return;
+    if (isActualObject(value)) {
 
-      if (key == '$$hashKey')
-        return;
-
-      if (isActualObject(value)) {
-
-        if (_.isEmpty(value)) {
-          result[key] = value;
-        }
-        else if (!preventNestedDiff) {
-          var diff = diffObjectChanges(oldValue, value);
-          if (diff) result[key] = diff;
-        }
-
-      } else {
+      if (_.isEmpty(value)) {
         result[key] = value;
       }
-
-      // If a nested object is identical between newItem and oldItem, it
-      // is initially attached as an empty object. Here we remove it from
-      // the result if it was not empty from the beginning.
-      if (isActualObject(result[key]) && _.keys(result[key]).length === 0) {
-        if (_.keys(value).length !== 0)
-          delete result[key];
+      else if (!preventNestedDiff) {
+        var diff = diffObjectChanges(oldValue, value);
+        if (diff) result[key] = diff;
       }
-    });
-  }
+
+    } else {
+      result[key] = value;
+    }
+
+    // If a nested object is identical between newItem and oldItem, it
+    // is initially attached as an empty object. Here we remove it from
+    // the result if it was not empty from the beginning.
+    if (isActualObject(result[key]) && _.keys(result[key]).length === 0) {
+      if (_.keys(value).length !== 0)
+        delete result[key];
+    }
+  });
 
   var resultKeys = _.keys(result);
   var emptyResult = resultKeys.length === 0;

--- a/lib/diff-array.js
+++ b/lib/diff-array.js
@@ -143,8 +143,12 @@ var diffObjectChanges = function (oldItem, newItem, preventNestedDiff) {
   } else {
 
     angular.forEach(newItem, function (value, key) {
+      var oldValue;
 
-      if (oldItem && angular.equals(value, oldItem[key]))
+      if (oldItem && typeof oldItem === 'object')
+        oldValue = oldItem[key];
+
+      if (oldItem && angular.equals(value, oldValue))
         return;
 
       if (key == '$$hashKey')
@@ -156,7 +160,7 @@ var diffObjectChanges = function (oldItem, newItem, preventNestedDiff) {
           result[key] = value;
         }
         else if (!preventNestedDiff) {
-          var diff = diffObjectChanges(oldItem[key], value);
+          var diff = diffObjectChanges(oldValue, value);
           if (diff) result[key] = diff;
         }
 
@@ -227,30 +231,24 @@ var handleDeepProperties = function(object, paths, cb) {
     var currentObject = object;
 
     for (var i = 0; i < props.length - 1; i++) {
-      if(_.isUndefined(currentObject[props[i]])){
+      if (!_.isObject(currentObject[props[i]]))
         currentObject[props[i]] = {};
-      }
       currentObject = currentObject[props[i]];
     }
-
     cb(currentObject, props[i], value);
   });
 };
 
-// Diffs two objects and returns the keys that have been added or changed.
-// Can be used to construct a Mongo {$set: {}} modifier
 var deepCopyObjectChanges = function (oldItem, newItem) {
   var setDiff = diffObjectChanges(oldItem, newItem);
-
-  handleDeepProperties(oldItem, setDiff, function(object, prop, value) {
+  handleDeepProperties(oldItem, setDiff, function setter(object, prop, value) {
     object[prop] = value;
   });
 };
 
 var deepCopyObjectRemovals = function (oldItem, newItem) {
   var unsetDiff = diffObjectRemovals(oldItem, newItem);
-
-  handleDeepProperties(oldItem, unsetDiff, function(object, prop) {
+  handleDeepProperties(oldItem, unsetDiff, function deleter(object, prop) {
     delete object[prop];
   });
 };

--- a/tests/integration/angular-meteor-collection-spec.js
+++ b/tests/integration/angular-meteor-collection-spec.js
@@ -32,7 +32,7 @@ describe('$meteorCollection service', function() {
 
     spyOn($rootScope, '$apply').and.callThrough();
 
-    MyCollection = new Mongo.Collection();
+    MyCollection = new Mongo.Collection(null);
     MyCollection.insert(testObjects[0]);
     MyCollection.insert(testObjects[1]);
     MyCollection.insert(testObjects[2]);

--- a/tests/integration/angular-meteor-collection-spec.js
+++ b/tests/integration/angular-meteor-collection-spec.js
@@ -69,6 +69,62 @@ describe('$meteorCollection service', function() {
       expect($rootScope.$apply).toHaveBeenCalled();
     });
 
+    it('should update the array when a collection item object-field is assigned a deep-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: {}});
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 'v'}}}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item primitive-field is assigned a deep-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: 1});
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 'v'}}}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item null-field is assigned a deep-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: null});
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 'v'}}}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item null-field is assigned a shallow-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: null});
+      MyCollection.update(item._id, {a: {subfield: 'v'}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item nested-object is nulled', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: {subfield: 'v'}});
+      MyCollection.update(item._id, {a: null});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item non-null-subfield is nulled', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: {subfield: 'v'}});
+      MyCollection.update(item._id, {a: {subfield: null}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item null-subfield is assigned a primitive', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: {subfield: null}});
+      MyCollection.update(item._id, {a: {subfield: 'v'}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
     it('should update the array when an item is removed from the collection', function() {
       // arrange
       var anyItem = MyCollection.findOne({});

--- a/tests/integration/angular-meteor-collection-spec.js
+++ b/tests/integration/angular-meteor-collection-spec.js
@@ -69,6 +69,14 @@ describe('$meteorCollection service', function() {
       expect($rootScope.$apply).toHaveBeenCalled();
     });
 
+    it('should update the array when a collection item unset-field is assigned a deep-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {$unset: {a: 1}});
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 'v'}}}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
     it('should update the array when a collection item object-field is assigned a deep-object', function() {
       var item = MyCollection.findOne();
       MyCollection.update(item._id, {a: {}});

--- a/tests/integration/angular-meteor-collection-spec.js
+++ b/tests/integration/angular-meteor-collection-spec.js
@@ -4,67 +4,57 @@ describe('$meteorCollection service', function() {
       $rootScope,
       $timeout,
       meteorArray,
-      testObjects = [
-      {
-        'a' : 1,
-        'b' : 2
-      },
-      {
-        'a' : 3,
-        'b' : 4
-      },
-      {
-        'a' : 5,
-        'b' : 6
-      }
-      ];
+      testObjects;
 
-  beforeEach(angular.mock.module('angular-meteor'));
-
+  // Setup jasmine.
   beforeEach(function() {
     jasmine.addMatchers(customMatchers);
   });
 
+  // Inject angular stuff.
+  beforeEach(angular.mock.module('angular-meteor'));
   beforeEach(angular.mock.inject(function(_$meteorCollection_, _$rootScope_, _$timeout_) {
     $meteorCollection = _$meteorCollection_;
     $rootScope = _$rootScope_;
     $timeout = _$timeout_;
+  }));
 
+  // Initialize spies.
+  beforeEach(function(){
     spyOn($rootScope, '$apply').and.callThrough();
+  });
 
+  // Initialize data.
+  beforeEach(function(){
+    testObjects = [
+      {'a' : 1, 'b' : 2},
+      {'a' : 3, 'b' : 4},
+      {'a' : 5, 'b' : 6}];
     MyCollection = new Mongo.Collection(null);
     MyCollection.insert(testObjects[0]);
     MyCollection.insert(testObjects[1]);
     MyCollection.insert(testObjects[2]);
-
     meteorArray = $meteorCollection(MyCollection, false);
-  }));
+  });
+
 
   describe('initialisation', function() {
     it('should return an array with all items in the Mongo Collection', function() {
-      // assert
       expect(meteorArray).toEqualCollection(MyCollection);
     });
   });
 
+
   describe('collection updates', function() {
     it('should update the array when a new item is inserted into the collection', function() {
-      // act
       MyCollection.insert({ a : '7', b: '8'});
-
-      // assert
       expect(meteorArray).toEqualCollection(MyCollection);
       expect($rootScope.$apply).toHaveBeenCalled();
     });
 
     it('should update the array when an item is updated in the collection', function() {
-      // arrange
       var anyItem = MyCollection.findOne({});
-
-      // act
       MyCollection.update({ _id : anyItem._id }, { a : '7', b : '8'});
-
-      // assert
       expect(meteorArray).toEqualCollection(MyCollection);
       expect($rootScope.$apply).toHaveBeenCalled();
     });
@@ -142,32 +132,23 @@ describe('$meteorCollection service', function() {
     });
 
     it('should update the array when an item is removed from the collection', function() {
-      // arrange
       var anyItem = MyCollection.findOne({});
-
-      // act
       MyCollection.remove({ _id : anyItem._id });
-
-      // assert
       expect(meteorArray).toEqualCollection(MyCollection);
       expect($rootScope.$apply).toHaveBeenCalled();
     });
 
-    it('should update the array when multiple changed occur on the collection', function() {
-      // arrange
+    it('should update the array when multiple changes occur on the collection', function() {
       var anyItem = MyCollection.findOne({});
       var anotherItem = MyCollection.findOne({a : '1'});
-
-      // act
       MyCollection.remove({ _id : anyItem._id });
       MyCollection.update({ _id : anotherItem }, { $set : { b : '100 '}});
       MyCollection.insert({ a : '7', b : '8'});
-
-      // assert
       expect(meteorArray).toEqualCollection(MyCollection);
       expect($rootScope.$apply).toHaveBeenCalled();
     });
   });
+
 
   describe('reactive cursor', function() {
     it('should update the array when the reactive cursor function recomputes', function() {
@@ -186,6 +167,7 @@ describe('$meteorCollection service', function() {
       expect(meteorReactiveArray).toEqualCollection(MyCollection);
     });
   });
+
 
   describe('autobind off', function() {
     var notAutoArray;
@@ -221,6 +203,7 @@ describe('$meteorCollection service', function() {
     });
   });
 
+
   describe('autobind on', function() {
     beforeEach(function() {
       meteorArray = $meteorCollection(MyCollection);
@@ -228,67 +211,48 @@ describe('$meteorCollection service', function() {
     });
 
     it('should update the collection when a new item is pushed into the array', function() {
-      // act
-      meteorArray.push({
-        a : '7',
-        b: '8'
-      });
+      meteorArray.push({a : '7', b: '8'});
       $rootScope.$apply();
-
-      // assert
       expect(meteorArray).toEqualCollection(MyCollection);
     });
 
     it('should update the collection when an item is changed in the array', function() {
-      // act
       meteorArray[0].a = 888;
-
       $rootScope.$apply();
-
-      // assert
       expect(meteorArray).toEqualCollection(MyCollection);
     });
 
     it('should update the collection when an item is removed from the array', function() {
-      // act
       meteorArray.splice(0, 1);
-
       $rootScope.$apply();
-
-      // assert
       expect(meteorArray).toEqualCollection(MyCollection);
     });
   });
 
+
   describe('observe server changes', function() {
 
+    // Cleaning up after each test.
     beforeEach(function() {
-      // Cleaning up after each test.
       bigCollection.find({}).forEach(function(doc) {
         bigCollection.remove(doc._id);
       });
-
       for (var i = 0; i < 100; i++) {
         bigCollection.insert({count: i});
       }
     });
 
     it('$apply executed twice', function() {
-
       var $ngCol = $meteorCollection(bigCollection);
-
       expect($rootScope.$apply).toHaveBeenCalled();
-
       expect($ngCol).toEqualCollection(bigCollection);
 
       // No matter how much elements MyCollection contains
       // $rootScope.$apply should be called twice.
       expect($rootScope.$apply.calls.count()).toEqual(2);
-
     });
 
     it('push updates from client handled correctly', function() {
-
       $rootScope.limit = 10;
       var $ngCol = $meteorCollection(function() {
         return bigCollection.find({}, {
@@ -303,14 +267,12 @@ describe('$meteorCollection service', function() {
       }
 
       $timeout.flush();
-
       expect($ngCol.length).toEqual(10);
       expect($ngCol.save).toHaveBeenCalled();
       expect($ngCol.save.calls.count()).toEqual(6);
     });
 
     it('remove updates from client handled correctly', function() {
-
       $rootScope.limit = 10;
       var $ngCol = $meteorCollection(function() {
         return bigCollection.find({}, {
@@ -331,8 +293,8 @@ describe('$meteorCollection service', function() {
       expect($ngCol.remove).toHaveBeenCalled();
       expect($ngCol.remove.calls.count()).toEqual(2);
     });
-
   });
+
 
   describe('objects with $$hashkey', function() {
     it('should be saved to the collection when save is called', function(done) {
@@ -362,9 +324,9 @@ describe('$meteorCollection service', function() {
     });
   });
 
+
   describe('objects with date', function() {
     it('should be saved to the collection when save is called', function(done) {
-
       var itemChanged = meteorArray[0];
       itemChanged.a = new Date("October 13, 2014 11:13:00");
 

--- a/tests/integration/angular-meteor-collection-spec.js
+++ b/tests/integration/angular-meteor-collection-spec.js
@@ -85,6 +85,14 @@ describe('$meteorCollection service', function() {
       expect($rootScope.$apply).toHaveBeenCalled();
     });
 
+    it('should update the array when a collection item array-field is assigned a deep-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: []});
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 'v'}}}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
     it('should update the array when a collection item primitive-field is assigned a deep-object', function() {
       var item = MyCollection.findOne();
       MyCollection.update(item._id, {a: 1});

--- a/tests/integration/angular-meteor-collection-spec.js
+++ b/tests/integration/angular-meteor-collection-spec.js
@@ -91,6 +91,14 @@ describe('$meteorCollection service', function() {
       expect($rootScope.$apply).toHaveBeenCalled();
     });
 
+    it('should update the array when a collection item falsy primitive-field is assigned a deep-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: 0});
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 'v'}}}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
     it('should update the array when a collection item null-field is assigned a deep-object', function() {
       var item = MyCollection.findOne();
       MyCollection.update(item._id, {a: null});
@@ -103,6 +111,14 @@ describe('$meteorCollection service', function() {
       var item = MyCollection.findOne();
       MyCollection.update(item._id, {a: null});
       MyCollection.update(item._id, {a: {subfield: 'v'}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item null-field is assigned a array-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: null});
+      MyCollection.update(item._id, {a: [1, 2, 3]});
       expect(meteorArray).toEqualCollection(MyCollection);
       expect($rootScope.$apply).toHaveBeenCalled();
     });
@@ -127,6 +143,30 @@ describe('$meteorCollection service', function() {
       var item = MyCollection.findOne();
       MyCollection.update(item._id, {a: {subfield: null}});
       MyCollection.update(item._id, {a: {subfield: 'v'}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item null-subfield is assigned a array-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: {subfield: null}});
+      MyCollection.update(item._id, {a: {subfield: [1, 2, 3]}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item deep-field is assigned a primitive', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 0}}}});
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 1}}}});
+      expect(meteorArray).toEqualCollection(MyCollection);
+      expect($rootScope.$apply).toHaveBeenCalled();
+    });
+
+    it('should update the array when a collection item deep-field is assigned a deep-object', function() {
+      var item = MyCollection.findOne();
+      MyCollection.update(item._id, {a: {L1: null}});
+      MyCollection.update(item._id, {a: {L1: {L2: {L3: 1}}}});
       expect(meteorArray).toEqualCollection(MyCollection);
       expect($rootScope.$apply).toHaveBeenCalled();
     });


### PR DESCRIPTION
Several different combinations of "new-field-type" and "previous-field-type" led to broken behavior on meteorCollection. Having null as a previous value on a field, for instance, could break if the field was both at a shallow or a deep position in the object. Big problem is the real collection data is updated and persisted, but the angular collection sync code would raise a TypeError some time after that, and potentially affect angular execution. 

This PR assures good behavior on the scenarios described by the added tests, but the sad reality is that dealing with object-diff and read-write of deep fields is challenging. I think we should consider bringing pieces of more stable code into angular-meteor in order to improve diff-array.js. 

For example, lodash ```_.get```, ```_.set``` and ```_.has``` may help us a great deal. A stripped version of the library with only these three functions will add something around 3KB to the minified footprint.