### PR TITLE
fix(AngularMeteorObject): delete server properties after unset changes

### DIFF
--- a/package.js
+++ b/package.js
@@ -72,6 +72,7 @@ Package.onTest(function(api) {
     'tests/integration/angular-meteor-session-spec.js',
     'tests/integration/angular-meteor-diff-array-spec.js',
     'tests/integration/angular-meteor-collection-spec.js',
+    'tests/integration/angular-meteor-object-spec.js',
     'tests/integration/angular-meteor-reactive-scope-spec.js',
     'tests/integration/angular-meteor-utils-spec.js',
     'tests/integration/test_collections.js'

--- a/tests/integration/angular-meteor-object-spec.js
+++ b/tests/integration/angular-meteor-object-spec.js
@@ -1,0 +1,71 @@
+describe('$meteorObject service', function () {
+  var $meteorObject,
+      TestCollection
+      id,
+      meteorObject;
+
+  beforeEach(angular.mock.module('angular-meteor'));
+
+  beforeEach(angular.mock.inject(function (_$meteorObject_) {
+    $meteorObject = _$meteorObject_;
+  }));
+
+  beforeEach(function () {
+    id = 'test_1'
+    var data = { _id: id, a: 1, b: 2 };
+
+    TestCollection = new Mongo.Collection(null);
+    TestCollection.insert(data);
+
+    meteorObject = $meteorObject(TestCollection, id, false);
+  });
+
+  it('should delete the property when unset in the collection', function () {
+    TestCollection.update(id, { $unset: { a: 1 } });
+
+    Tracker.flush();
+
+    var doc = TestCollection.findOne(id);
+    expect(doc.a).not.toBeDefined('document have unset property'); // make sure it was unset in mongo
+
+    expect(meteorObject.a).not.toBeDefined('angular meteor object have unset property');
+  });
+
+
+  it('should keep the client only property after autorun updates', function () {
+    meteorObject.clientProp = 'keep';
+
+    TestCollection.update(id, { $unset: { a: 1 } });
+
+    Tracker.flush();
+
+    var doc = TestCollection.findOne(id);
+    expect(doc.clientProp).not.toBeDefined('document have client property');  // make sure it didn't set to mongo
+
+    expect(meteorObject.a).not.toBeDefined('angular meteor object have unset property');
+    expect(meteorObject.clientProp).toBeDefined('angular meteor object doesnt have client property');
+  });
+
+  it('should delete server and client side properties when object removed from the collection', function () {
+    meteorObject.clientProp = 'keep'
+    TestCollection.remove(id);
+
+    Tracker.flush();
+
+    expect(meteorObject.a).not.toBeDefined();
+    expect(meteorObject.b).not.toBeDefined();
+    expect(meteorObject._id).not.toBeDefined();
+    expect(meteorObject.clientProp).not.toBeDefined();
+  });
+
+  describe('#reset()', function () {
+
+    it('should remove the client property', function () {
+      meteorObject.clientProp = 'delete';
+
+      meteorObject.reset();
+
+      expect(meteorObject.clientProp).not.toBeDefined('angular meteor object doesnt have client property');
+    });
+  });
+});


### PR DESCRIPTION
I didn't use deepCopyChanges and deepCopyRemovals, because I wasn't able to copy only the changes / removals without the client (user and internals) properties.

* AngularMeteorObject.reset(): Add `keepClientProps` argument to remove only
server side removed properties, in compare when called by the user that
will remove all properties.
* AngularMeteorObject: Add _serverBackup - to be able to detect between
server unset properties and client only properties.
* AngularMeteorObject: Add tests