### PR TITLE
Use angular $parse to handle nested mode (a.b.value)

### DIFF
--- a/modules/angular-meteor-session.js
+++ b/modules/angular-meteor-session.js
@@ -2,7 +2,7 @@
 var angularMeteorSession = angular.module('angular-meteor.session', ['angular-meteor.utils']);
 
 angularMeteorSession.factory('$meteorSession', ['$meteorUtils', '$parse',
-  function ($meteorUtils, '$parse') {
+  function ($meteorUtils, $parse) {
     return function (session) {
 
       return {

--- a/modules/angular-meteor-session.js
+++ b/modules/angular-meteor-session.js
@@ -1,19 +1,21 @@
 'use strict';
 var angularMeteorSession = angular.module('angular-meteor.session', ['angular-meteor.utils']);
 
-angularMeteorSession.factory('$meteorSession', ['$meteorUtils',
-  function ($meteorUtils) {
+angularMeteorSession.factory('$meteorSession', ['$meteorUtils', '$parse',
+  function ($meteorUtils, '$parse') {
     return function (session) {
 
       return {
 
         bind: function(scope, model) {
+          var getter = $parse(model);
+          var setter = getter.assign;
           $meteorUtils.autorun(scope, function() {
-            scope[model] = Session.get(session);
+            setter(scope, Session.get(session));
           });
 
-          scope.$watch(model, function (newItem, oldItem) {
-            Session.set(session, scope[model]);
+          scope.$watch(model, function(newItem, oldItem) {
+            Session.set(session, getter(scope));
           }, true);
 
         }

--- a/tests/integration/angular-meteor-session-spec.js
+++ b/tests/integration/angular-meteor-session-spec.js
@@ -30,4 +30,35 @@ describe('$meteorSession service', function () {
 
     expect(Session.get('myVar')).toEqual(4);
   });
+
+
+  it('should update the scope variable nested property when session variable changes', function () {
+    Session.set('myVar', 3);
+    $scope.a ={
+      b:{
+        myVar: 3
+      }
+    };
+
+    $meteorSession('myVar').bind($scope, 'a.b.myVar');
+
+    Session.set('myVar', 4);
+    Tracker.flush(); // get the computations to run
+
+    expect($scope.a.b.myVar).toEqual(4);
+  });
+
+  it('should update the session variable when the scope variable nested property changes', function() {
+    $scope.a ={
+      b:{
+        myVar: 3
+      }
+    };
+    $meteorSession('myVar').bind($scope, 'a.b.myVar');
+
+    $scope.a.b.myVar = 4;
+    $rootScope.$apply();
+
+    expect(Session.get('myVar')).toEqual(4);
+  });
 });


### PR DESCRIPTION
MeteorSession doesn't work with nested mode something link 'a.b.c'
Fix it by using angular $parse