### PR TITLE
Remove unnecessary local update

### DIFF
--- a/modules/angular-meteor-collection.js
+++ b/modules/angular-meteor-collection.js
@@ -12,9 +12,6 @@ var angularMeteorCollection = angular.module('angular-meteor.collection',
 angularMeteorCollection.factory('AngularMeteorCollection', [
   '$q', '$meteorSubscribe', '$meteorUtils', '$rootScope', '$timeout', 'diffArray',
   function ($q, $meteorSubscribe, $meteorUtils, $rootScope, $timeout, diffArray) {
-    var deepCopyChanges = diffArray.deepCopyChanges;
-    var deepCopyRemovals = diffArray.deepCopyRemovals;
-
     function AngularMeteorCollection (cursor, collection, diffArrayFunc) {
       var data = [];
       data._serverBackup = [];
@@ -139,8 +136,8 @@ angularMeteorCollection.factory('AngularMeteorCollection', [
         },
 
         changedAt: function (doc, oldDoc, atIndex) {
-          deepCopyChanges(self[atIndex], doc);
-          deepCopyRemovals(self[atIndex], doc);
+          diffArray.deepCopyChanges(self[atIndex], doc);
+          diffArray.deepCopyRemovals(self[atIndex], doc);
           self._serverBackup[atIndex] = self[atIndex];
           applyPromise = self._safeApply(applyPromise);
         },

--- a/modules/angular-meteor-object.js
+++ b/modules/angular-meteor-object.js
@@ -9,7 +9,7 @@ angularMeteorObject.factory('AngularMeteorObject', [
     AngularMeteorObject.$$internalProps = [
       '$$collection', '$$options', '$$id', '$$hashkey', '$$internalProps', '$$scope',
       'save', 'reset', 'subscribe', 'stop', 'autorunComputation', 'unregisterAutoBind', 'unregisterAutoDestroy', 'getRawObject',
-      '_auto', '_setAutos', '_eventEmitter', '_serverBackup', '_updateLocal'
+      '_auto', '_setAutos', '_eventEmitter', '_serverBackup'
     ];
 
     function AngularMeteorObject (collection, id, options){
@@ -37,19 +37,16 @@ angularMeteorObject.factory('AngularMeteorObject', [
       return this;
     };
 
-    AngularMeteorObject.save = function(updates) {
-      var self = this;
+    AngularMeteorObject.save = function(changes) {
       var deferred = $q.defer();
+      var updates;
 
-      if (updates) {
-        this.$$collection.update(this._id, { $set: updates }, $meteorUtils.fulfill(deferred));
-        diffArray.deepCopyChanges(self, updates);
-      }
+      if (changes)
+        updates = { $set: changes };
+      else
+        updates = this.getRawObject();
 
-      else {
-        this.$$collection.update(this._id, this.getRawObject(), $meteorUtils.fulfill(deferred));
-      }
-
+      this.$$collection.update(this._id, updates, $meteorUtils.fulfill(deferred));
       return deferred.promise; 
     };
 

--- a/tests/integration/angular-meteor-object-spec.js
+++ b/tests/integration/angular-meteor-object-spec.js
@@ -40,7 +40,6 @@ describe('$meteorObject service', function () {
     expect(meteorObject.a).not.toBeDefined('angular meteor object have unset property');
   });
 
-
   it('should keep the client only property after autorun updates', function () {
     meteorObject.clientProp = 'keep';
 
@@ -82,6 +81,7 @@ describe('$meteorObject service', function () {
         c: 3
       });
 
+      Tracker.flush();
       expect(meteorObject.getRawObject()).toDeepEqual(doc);
     });
 


### PR DESCRIPTION
The tracker will do so by observing any changes made on the Meteor.Collection, thus unnecessary deep changes copy was removed