### PR TITLE
One more pass of meteorCollection re-factoring.

### DIFF
--- a/modules/angular-meteor-collection.js
+++ b/modules/angular-meteor-collection.js
@@ -275,29 +275,43 @@ angularMeteorCollection.factory('AngularMeteorCollection', [
 
     AngularMeteorCollection._saveChanges = function(changes) {
       // First applies changes to the collection itself.
+      var newDocs = [];
       for (var itemInd = changes.added.length - 1; itemInd >= 0; itemInd--) {
         this.splice(changes.added[itemInd].index, 1);
+        newDocs.push(changes.added[itemInd].item);
+      }
+      // Then saves all new docs in bulk.
+      if (newDocs.length) {
+        this.save(newDocs);
       }
 
-      // Then saves additions.
-      for (var itemInd = 0; itemInd < changes.added.length; itemInd++) {
-        this.save(changes.added[itemInd].item);
-      }
-
-      // Then saves removes.
+      // Collects docs to remove.
+      var removeDocs = [];
       for (var itemInd = 0; itemInd < changes.removed.length; itemInd++) {
-        this.remove(changes.removed[itemInd].item);
+        removeDocs.push(changes.removed[itemInd].item);
+      }
+      // Removes docs in bulk.
+      if (removeDocs.length) {
+        this.remove(removeDocs);
       }
 
-      // Then saves changes.
+      // Collects set and unset changes.
+      var setDocs = [], unsetDocs = [];
       for (var itemInd = 0; itemInd < changes.changed.length; itemInd++) {
         var change = changes.changed[itemInd];
         if (change.setDiff) {
-          this.save(change.setDiff);
+          setDocs.push(change.setDiff);
         }
         if (change.unsetDiff) {
-          this.save(change.unsetDiff, true);
+          unsetDocs.push(change.unsetDiff);
         }
+      }
+      // Then saves all changes in bulk.
+      if (setDocs.length) {
+        this.save(setDocs);
+      }
+      if (unsetDocs.length) {
+        this.save(unsetDocs, true);
       }
     };
 

--- a/modules/angular-meteor-collection.js
+++ b/modules/angular-meteor-collection.js
@@ -171,7 +171,7 @@ angularMeteorCollection.factory('AngularMeteorCollection', [
 
       var hUnsetTimeout = null;
       // Here we use $timeout to combine multiple updates that go
-      // one after another.
+      // each one after another.
       function unsetServerUpdateMode() {
         if (hUnsetTimeout) {
           $timeout.cancel(hUnsetTimeout);
@@ -232,7 +232,6 @@ angularMeteorCollection.factory('AngularMeteorCollection', [
         }
       });
   
-      var hTimeout = null;
       this._hDataAutorun = Tracker.autorun(function() {
         cursor.fetch();
         if (serverMode) {
@@ -247,9 +246,7 @@ angularMeteorCollection.factory('AngularMeteorCollection', [
     };
 
     AngularMeteorCollection._stopCursor = function() {
-      if (this._unsetAutoClientSave) {
-        this._unsetAutoClientSave();
-      }
+      this._unsetAutoClientSave();
 
       if (this._hObserve) {
         this._hObserve.stop();
@@ -385,6 +382,7 @@ var collectionUtils = {
   // Finds changes between two collections and saves differences.
   diff: function(newCollection, oldCollection, diffMethod) {
     var changes = {added: [], removed: [], changed: []};
+
     diffMethod(oldCollection, newCollection, {
       addedAt: function(id, item, index) {
         changes.added.push({item: item, index: index});

--- a/package.js
+++ b/package.js
@@ -60,7 +60,7 @@ Package.on_use(function (api) {
 Package.onTest(function(api) {
   api.use('sanjo:jasmine@0.13.6');
   api.use('urigo:angular');
-  api.use('angular:angular-mocks');
+  api.use('angular:angular-mocks@1.4.2');
 
   // auxiliary
   api.addFiles([

--- a/tests/integration/angular-meteor-collection-spec.js
+++ b/tests/integration/angular-meteor-collection-spec.js
@@ -254,7 +254,7 @@ describe('$meteorCollection service', function() {
     });
 
     it('should update the collection when a new item is pushed into the array', function() {
-      meteorArray.push({a : '7', b: '8'});
+      meteorArray.push({a: '7', b: '8'});
       $rootScope.$apply();
       expect(meteorArray).toEqualCollection(MyCollection);
     });
@@ -347,7 +347,7 @@ describe('$meteorCollection service', function() {
       $timeout.flush();
       expect($ngCol.length).toEqual(10);
       expect($ngCol.save).toHaveBeenCalled();
-      expect($ngCol.save.calls.count()).toEqual(6);
+      expect($ngCol.save.calls.count()).toEqual(1);
     });
 
     it('remove updates from client handled correctly', function() {
@@ -369,7 +369,7 @@ describe('$meteorCollection service', function() {
       // limit is set.
       expect($ngCol.length).toEqual(10);
       expect($ngCol.remove).toHaveBeenCalled();
-      expect($ngCol.remove.calls.count()).toEqual(2);
+      expect($ngCol.remove.calls.count()).toEqual(1);
     });
   });
 
@@ -386,7 +386,7 @@ describe('$meteorCollection service', function() {
 
       meteorArray.save();
 
-      expect({a : 444, b: 2}).toBeFoundExactlyInCollection(MyCollection);
+      expect({a: 444, b: 2}).toBeFoundExactlyInCollection(MyCollection);
     });
 
     it('should save objects with nested $$haskey fields when save is called', function() {
@@ -402,8 +402,7 @@ describe('$meteorCollection service', function() {
       itemChanged.a = new Date("October 13, 2014 11:13:00");
 
       meteorArray.save();
-
-      expect({a : new Date("October 13, 2014 11:13:00"), b: 2})
+      expect({a: new Date("October 13, 2014 11:13:00"), b: 2})
         .toBeFoundExactlyInCollection(MyCollection);
     });
 

--- a/tests/integration/angular-meteor-collection-spec.js
+++ b/tests/integration/angular-meteor-collection-spec.js
@@ -44,6 +44,11 @@ describe('$meteorCollection service', function() {
   });
 
   describe('collection updates', function() {
+
+    beforeEach(function() {
+      $timeout.flush();
+    });
+
     it('should update the array when a new item is inserted into the collection', function() {
       MyCollection.insert({ a : '7', b: '8'});
       expect(meteorArray).toEqualCollection(MyCollection);
@@ -316,9 +321,10 @@ describe('$meteorCollection service', function() {
 
     it('$apply executed twice', function() {
       var $ngCol = $meteorCollection(bigCollection);
+      $timeout.flush();
+
       expect($rootScope.$apply).toHaveBeenCalled();
       expect($ngCol).toEqualCollection(bigCollection);
-
       // No matter how much elements MyCollection contains
       // $rootScope.$apply should be called twice.
       expect($rootScope.$apply.calls.count()).toEqual(2);
@@ -389,7 +395,6 @@ describe('$meteorCollection service', function() {
       expect(itemWithNestedHashkeysRemoved).toBeFoundExactlyInCollection(MyCollection);
     });
   });
-
 
   describe('objects with date', function() {
     it('should be saved to the collection when save is called', function() {


### PR DESCRIPTION
Main purpose is to clearly separate server update logic from the client one.
So that we don’t have any special variable that sets mode globally (like "UPDATING_FROM_SERVER")
For each update from the server or any internal changes to the collection, we perform
_unsetAutoClientSave
… here changes go
_setAutoClientSave

Also ````collectionUtils```` has been changed to provide collection with the changes only,
saving of the changes collection take care of by itself from now own, which simplified code flow.

All Tracker.Autotuns now are stopped on the collection’s stop method as well.

Also, I seem to have understood the reason of https://github.com/meteor/simple-todos-angular/issues/2.
It was very likely due to uncontrollable ````setAutoBind````, which may have run
multiple time here https://github.com/Urigo/angular-meteor/blob/master/modules/angular-meteor-collection.js#L284, thus, ended up having multiple ````$watches```` at the same time.

#483 issue looks like fixed already.

ToDo app with the current commit deployed here http://ng-to-do-test.meteor.com.

angular:angular-mocks rolled back to the previous version; new version seems to require some new dependancies.

We also certainly need to devote some time to go through all the current bugs (particularly for meteorCollection) and fix them before the next version. @Urigo what do you think?
Also, how about to set up some code style guide to follow? Code files look sometimes too different to my mind.