### PR TITLE
docs(tutorialAngular2.step_00.html): fix typo index.ng.html -> index.…

### DIFF
--- a/.docs/angular-meteor/client/content/tutorials/angular2/steps/tutorialAngular2.step_00.html
+++ b/.docs/angular-meteor/client/content/tutorials/angular2/steps/tutorialAngular2.step_00.html
@@ -110,7 +110,7 @@ ES2015 & TypeScript both use modules. These are the `import` and `export` statem
 
 System.js is a module loader built into the `shmck:angular2` package. We'll use it to load our root component.
 
-__`index.ng.html`:__
+__`index.html`:__
 
     <body>
       <p>Nothing here</p>


### PR DESCRIPTION
…html

the text refers to the main index.html file and not the app specific index.ng.html