### PR TITLE
Spacing on tutorials, fix spacing on home, show lists

### DIFF
--- a/.docs/angular-meteor/client/content/tutorials/angular1/steps/tutorial.step_02.md
+++ b/.docs/angular-meteor/client/content/tutorials/angular1/steps/tutorial.step_02.md
@@ -37,7 +37,6 @@ The data model is now instantiated within the `PartiesListCtrl` controller.
 Although the controller is not yet doing very much, it plays a crucial role. By providing context for our data model, the controller allows us to establish data-binding between the model and the view. We connected the dots between the presentation, the data, and the logic components as follows:
 
 * The ngController directive, located on the `body` tag, references the name of our controller, `PartiesListCtrl` (located in the JavaScript file `app.js`).
-
 * The `PartiesListCtrl` controller attaches the party data to the `$scope` that was injected into our controller function. This controller scope is available to all bindings located within the `div ng-controller="PartiesListCtrl">` tag.
 
 # ng-annotate and .ng.js

--- a/.docs/angular-meteor/client/stylesheets/content/angular-2.import.less
+++ b/.docs/angular-meteor/client/stylesheets/content/angular-2.import.less
@@ -15,6 +15,7 @@
 
     p {
       font-size: 1.2rem;
+      margin: 0 auto 1rem;
     }
   }
 

--- a/.docs/angular-meteor/client/stylesheets/content/api_tutorial/common.import.less
+++ b/.docs/angular-meteor/client/stylesheets/content/api_tutorial/common.import.less
@@ -4,7 +4,6 @@
   .main-content {
 
     margin-bottom: 6rem;
-
     font-size: 1.2rem;
     p,
     li,
@@ -13,6 +12,16 @@
     h3,
     hr {
       max-width: 640px;
+    }
+
+    ol {
+      list-style: decimal outside;
+      margin-left: 2rem;
+    }
+
+    ul {
+      list-style: disc outside;
+      margin-left: 2rem;
     }
   }
 }

--- a/.docs/angular-meteor/client/stylesheets/home/home.import.less
+++ b/.docs/angular-meteor/client/stylesheets/home/home.import.less
@@ -2,7 +2,6 @@
 
 .home {
   .main-unit {
-    margin-bottom: 6rem;
     text-align: center;
   }
 
@@ -45,7 +44,7 @@
 
   .intro {
     padding-bottom: 3rem;
-    padding-top: 1rem;
+    padding-top: 3rem;
     background-color: @second-background-color;
     margin: 3rem auto;
 

--- a/.docs/angular-meteor/client/stylesheets/main.less
+++ b/.docs/angular-meteor/client/stylesheets/main.less
@@ -54,6 +54,7 @@ hr {
 
 p {
   max-width: 640px;
+  margin: 0 0 1rem;
 }
 
 main {


### PR DESCRIPTION
# What's Changed
* Gave paragraphs in the tutorials some more breathing room
* Added list-style back in, it was missing and made some parts of the tutorial look weird (basically ignoring all markdown lists)
* fixed paddings / margins on the home page. 