### PR TITLE
Fix idStringify for recent versions of Meteor

### DIFF
--- a/lib/diff-array.js
+++ b/lib/diff-array.js
@@ -4,8 +4,8 @@ var module = angular.module('diffArray', ['getUpdates']);
 
 module.factory('diffArray', ['getUpdates',
   function(getUpdates) {
-    var idStringify = LocalCollection._idStringify;
-    var idParse = LocalCollection._idParse;
+    var idStringify = LocalCollection._idStringify || Package['mongo-id'].MongoID.idStringify;
+    var idParse = LocalCollection._idParse || Package['mongo-id'].MongoID.idParse;
 
     // Calculates the differences between `lastSeqArray` and
     // `seqArray` and calls appropriate functions from `callbacks`.
@@ -142,7 +142,7 @@ module.factory('diffArray', ['getUpdates',
           if (subObj[k] == null) subObj[k] = [];
           if (subObj[k].length == parseInt(nextKey)) subObj[k].push(null);
         }
-        
+
         else if (subObj[k] == null || !isHash(subObj[k])) {
           subObj[k] = {};
         }

--- a/package.js
+++ b/package.js
@@ -30,7 +30,12 @@ Package.on_use(function (api) {
   api.versionsFrom('METEOR@0.9.0.1');
 
   api.use('angular:angular@1.4.4', 'client');
-  api.use('minimongo');  // for idStringify
+  api.use('minimongo');
+  if (Package['mongo-id']) {
+    // Since commit b3096e93661bc79bab73a63bae0e14643030a9a3, MongoId is
+    // in a separate package. We need to use it for idParse and idStringify.
+    api.use('mongo-id');
+  }
   api.use('observe-sequence');
   api.use('dburles:mongo-collection-instances@0.3.4', 'client'); // For getCollectionByName
 


### PR DESCRIPTION
Since commit meteor/meteor@b3096e93, MongoId and the _idStringify
(or _idParse) method is in a separate package.

diffArray currently assumes the _idStringify and _idParse methods to
be in LocalCollection, but this isn't true anymore in recent versions
of Meteor. Therefore, diffArray() throws an error on (for example)
Meteor 1.2.

This commit fixes this issue by using the mongo-id package if we cannot
find LocalCollection._idStringify and LocalCollection._idParse are
undefined.