### PR TITLE
Collection: Fix wrong variable in movedTo()

### DIFF
--- a/modules/angular-meteor-collection.js
+++ b/modules/angular-meteor-collection.js
@@ -201,7 +201,7 @@ angularMeteorCollection.factory('AngularMeteorCollection', [
           self.splice(fromIndex, 1);
           self.splice(toIndex, 0, doc);
           self._serverBackup.splice(fromIndex, 1);
-          self._serverBackup.splice(i, 0, doc);
+          self._serverBackup.splice(toIndex, 0, doc);
           setServerUpdateMode();
         },
 


### PR DESCRIPTION
Fix a wrong variable being used in the movedTo() observe function.
This fixes a regression introduced by a recent refactor (commit 88b50bf).