### PR TITLE
functionality and spec for passing a function as bound result to mete…

### DIFF
--- a/modules/angular-meteor-utils.js
+++ b/modules/angular-meteor-utils.js
@@ -45,6 +45,8 @@ angularMeteorUtils.service('$meteorUtils', [
       return function(err, result) {
         if (err)
           deferred.reject(boundError == null ? err : boundError);
+        else if (typeof boundResult == "function")
+          deferred.resolve(boundResult == null ? result : boundResult(result));
         else
           deferred.resolve(boundResult == null ? result : boundResult);
       };

--- a/tests/integration/angular-meteor-utils-spec.js
+++ b/tests/integration/angular-meteor-utils-spec.js
@@ -130,6 +130,24 @@ describe('$meteorUtils service', function () {
       expect(deferred.reject.calls.count()).toEqual(1);
       expect(deferred.reject.calls.mostRecent().args[0]).toEqual(err);
     });
+    
+    it('should return bound result of an async callback from an arbitrary function', function() {
+      var fn = function(action, _id) {
+        return {_id: _id, action: action }
+      }
+      var createFulfill = _.partial(fn, 'inserted')
+      var fulfill = $meteorUtils.fulfill(deferred, err, result);
+      var err = Error();
+      var result = '_id';
+    
+      fulfill(null, createFulfill(result));
+      expect(deferred.resolve.calls.count()).toEqual(1);
+      expect(deferred.resolve.calls.mostRecent().args[0]).toEqual({ _id: result, action: 'inserted' });
+    
+      fulfill(Error());
+      expect(deferred.reject.calls.count()).toEqual(1);
+      expect(deferred.reject.calls.mostRecent().args[0]).toEqual(err);
+    });
   });
 
   describe('promissor', function() {


### PR DESCRIPTION
…orUtils.fulfill

Proposed fix for #686 to return ID of object inserted into a collection.  Retains intention of code to return both ID and action, and puts a basic spec in place for ```$meteorUtils.fulfill```

```javascript
$scope.Todos.save(newTodo).then(function(response) {
    // response now returns: [{
    //     id: "<_id>",
    //     action: "inserted"
    // }];
}
```