### PR TITLE
added missing dependencies for meteor 1.2 in tests.

### DIFF
--- a/package.js
+++ b/package.js
@@ -44,6 +44,11 @@ Package.on_use(function (api) {
   }
   api.use('dburles:mongo-collection-instances@0.3.4', 'client'); // For getCollectionByName
 
+  api.use('tracker');
+  api.use('underscore');
+  api.use('session');
+  api.use('mongo');
+
   // Files to load in Client only.
   api.add_files([
     // Lib Files
@@ -70,6 +75,11 @@ Package.onTest(function(api) {
   api.use('angular');
   api.use('angular:angular-mocks@1.4.4');
   api.use('mdg:camera@1.1.5');
+
+  api.use('underscore');
+  api.use('session');
+  api.use('mongo');
+  api.use('tracker');
 
   // auxiliary
   api.addFiles([


### PR DESCRIPTION
@Urigo check this out. I've added dependencies to the on_use and to the on_test. we need them for both, cause without this packages our package can't work. It used to always work because of meteor-platform, but now if someone doesn't use all of the packages we need it might break. This should fix it..
