### PR TITLE
(meteorSubscribe) Added options object argument with a user supplied onStop callback 

### DIFF
--- a/.docs/angular-meteor/client/content/api/api.subscribe.html
+++ b/.docs/angular-meteor/client/content/api/api.subscribe.html
@@ -47,6 +47,14 @@ Calling $scope.$meteorSubscribe will automatically stop the subscription when th
   <td><p>Optional arguments passed to publisher function on server.</p></td>
   <td><a href="" class="label type-hint type-hint-object">No</a></td>
 </tr>
+<tr>
+  <td>onStop</td>
+  <td><a href="" class="label type-hint type-hint-object">Object with onStop callback</a></td>
+  <td><p>The onStop callback is called after the returned promise is resolved. It will be called with a Meteor.Error
+    if the subscription fails or is terminated by the server. If the subscription is stopped by calling stop on the
+    subscription handle or inside the publication, onStop is called with no arguments.</p></td>
+  <td><a href="" class="label type-hint type-hint-object">No</a></td>
+</tr>
 </tbody>
 </table>
 
@@ -84,7 +92,7 @@ Calling $scope.$meteorSubscribe will automatically stop the subscription when th
             subscriptionHandle.stop();
           });
 
-          $scope.$meteorSubscribe('books').then(function(subscriptionHandle){
+          $scope.$meteorSubscribe('books', {onStop: notifyUser}).then(function(subscriptionHandle){
             // Bind all the todos to $scope.books
             $scope.books = $meteor.collection(Books);
 
@@ -92,6 +100,15 @@ Calling $scope.$meteorSubscribe will automatically stop the subscription when th
 
             // No need to stop the subscription, it will automatically close on scope destroy
           });
+
+          ////////////
+
+          function notifyUser(err) {
+            if (err)
+              alert(err.reason);
+            else
+              alert('Books subscription was stopped.');
+          }
         }
       ]);
     }

--- a/modules/angular-meteor-subscribe.js
+++ b/modules/angular-meteor-subscribe.js
@@ -8,7 +8,6 @@ angularMeteorSubscribe.service('$meteorSubscribe', ['$q',
     this._subscribe = function(scope, deferred, args) {
       var subscription = null;
       var lastArg = args[args.length - 1];
-      var promiseFulfilled = deferred.promise.$$state.status;
 
       // User supplied onStop callback
       // save it for later use and remove
@@ -25,7 +24,7 @@ angularMeteorSubscribe.service('$meteorSubscribe', ['$q',
           deferred.resolve(subscription);
         },
         onStop: function(err) {
-          if (!promiseFulfilled) {
+          if (!deferred.promise.$$state.status) {
             if (err)
               deferred.reject(err);
             else

--- a/package.js
+++ b/package.js
@@ -96,6 +96,7 @@ Package.onTest(function(api) {
     'tests/integration/angular-meteor-camera-spec.js',
     'tests/integration/angular-meteor-diff-array-spec.js',
     'tests/integration/angular-meteor-get-updates-spec.js',
+    'tests/integration/angular-meteor-subscribe-spec.js',
     'tests/integration/angular-meteor-collection-spec.js',
     'tests/integration/angular-meteor-object-spec.js',
     'tests/integration/angular-meteor-reactive-scope-spec.js',

--- a/tests/integration/angular-meteor-subscribe-spec.js
+++ b/tests/integration/angular-meteor-subscribe-spec.js
@@ -1,0 +1,98 @@
+describe('$meteorSubscribe service', function () {
+  var $meteorSubscribe,
+    $rootScope,
+    $scope,
+    ready,
+    stop;
+
+  var $subscriptionHandleMock = function () {
+    return {
+      stop: function () {
+      }
+    };
+  };
+
+  beforeEach(angular.mock.module('angular-meteor'));
+  beforeEach(angular.mock.inject(function (_$meteorSubscribe_, _$rootScope_) {
+    $meteorSubscribe = _$meteorSubscribe_;
+    $rootScope = _$rootScope_;
+    $scope = $rootScope.$new();
+  }));
+
+  beforeEach(function () {
+    spyOn(Meteor, 'subscribe').and.callFake(function () {
+      stop = arguments[arguments.length - 1].onStop;
+      ready = arguments[arguments.length - 1].onReady;
+
+      return $subscriptionHandleMock;
+    });
+  });
+
+  describe('$scope.$meteorSubscribe', function () {
+
+    it('should call Meteor.subscribe with publication arguments and event callbacks ', function () {
+      $scope.$meteorSubscribe('subscription', 1, 2, 3);
+
+      expect(Meteor.subscribe)
+        .toHaveBeenCalledWith('subscription', 1, 2, 3, {
+          onReady: jasmine.any(Function),
+          onStop: jasmine.any(Function)
+        });
+    });
+
+    it('should return promise that is resolved when subscription is ready', function (done) {
+      $scope.$meteorSubscribe('subscription', 1, 2, 3)
+        .then(function (handle) {
+          expect(handle).toEqual($subscriptionHandleMock);
+        })
+        .finally(done);
+
+      ready();
+      $rootScope.$digest();
+    });
+
+    it('should return promise that is rejected with a Meteor.Error', function (done) {
+      var promise = $scope.$meteorSubscribe('subscription', 1, 2, 3);
+
+      promise.catch(function (err) {
+        if (err instanceof Meteor.Error) done();
+        else done.fail();
+      });
+
+      stop();
+      $rootScope.$digest();
+    });
+
+  });
+
+  describe('pass onStop argument', function () {
+
+    it('should call onStop with Meteor.Error when onStop event called for subscription that was resolved', function (done) {
+      var error = new Meteor.Error('Error', 'reason');
+
+      $scope.$meteorSubscribe('subscription', 1, 2, 3,
+        {
+          onStop: function (err) {
+            if (err === error) done();
+            else done.fail();
+          }
+        });
+
+      ready();
+      stop(error);
+    });
+
+    it('should call onStop when subscription is stopped', function (done) {
+      $scope.$meteorSubscribe('subscription', 1, 2, 3,
+        {
+          onStop: function (err) {
+            if (!err) done();
+            else done.fail();
+          }
+        });
+
+      ready();
+      stop();
+    });
+  });
+});


### PR DESCRIPTION
* User supplied onStop will be called after subscription is already active and was stopped by an error or call to stop method.
* This does not break the stable API of meteorSubscribe and and adds a way to be notified on an event of subscription stopping after it was resolved.
* Added tests for meteorSubscribe service.
* This PR also removes deprecated argument of Meteor.subscribe. https://github.com/meteor/meteor/blob/master/packages/ddp-client/livedata_connection.js#L466-L496
* Meteor docs quote describing onStop: "The onStop callback is called with a Meteor.Error if the subscription fails or is terminated by the server. If the subscription is stopped by calling stop on the subscription handle or inside the publication, onStop is called with no arguments."