### PR TITLE
updating version of check dependency 1.0.2 -> 1.0.6

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -22,7 +22,7 @@
     ],
     [
       "check",
-      "1.0.2"
+      "1.0.6"
     ],
     [
       "dburles:mongo-collection-instances",


### PR DESCRIPTION
I was still seeing the issue #734.  I'm not exactly certain what is going on, but my best guess is that angular-meteor and my other packages are requesting to use different versions of the ```check``` package as a dependency.

Upgrading to latest version of ```check``` resolved the issue for me.  Hopefully this is final fix needed to resolve this bug.
