### PR TITLE
Fix ObjectID being converted to Object during updates

### DIFF
--- a/modules/angular-meteor-utils.js
+++ b/modules/angular-meteor-utils.js
@@ -29,6 +29,7 @@ angularMeteorUtils.service('$meteorUtils', [
       if( !angular.isObject(data) ||
         data instanceof Date ||
         data instanceof File ||
+        EJSON.toJSONValue(data).$type === 'oid' ||
         (typeof FS === 'object' && data instanceof FS.File)) {
         return data;
       }


### PR DESCRIPTION
Meteor collections currently require that _id be either a string or the EJSON
version of Mongo's ObjectID. When documents are being saved with ObjectID (such
as in early steps of the current angular tutorial on meteor.com), the
`stripDollarPrefixedKeys` method that is called by the `_upsertDoc` method of
`AngularMeteorCollection` causes ObjectIDs to be converted into POJOs, which
causes Meteor to throw errors about their data types and messes everything up.

This commit causes values with EJSON type 'oid' (such as the server-side
ObjectIDs) to pass through `stripDollarPrefixedKeys` without modification.