### PR TITLE
feature (html-build): change html build process to match the process …

### DIFF
--- a/.npm/plugin/compileNGTemplate/npm-shrinkwrap.json
+++ b/.npm/plugin/compileNGTemplate/npm-shrinkwrap.json
@@ -163,42 +163,6 @@
             }
           }
         },
-        "uglify-js": {
-          "version": "2.4.24",
-          "dependencies": {
-            "async": {
-              "version": "0.2.10"
-            },
-            "source-map": {
-              "version": "0.1.34",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2"
-            },
-            "yargs": {
-              "version": "3.5.4",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1"
-                },
-                "decamelize": {
-                  "version": "1.0.0"
-                },
-                "window-size": {
-                  "version": "0.1.0"
-                },
-                "wordwrap": {
-                  "version": "0.0.2"
-                }
-              }
-            }
-          }
-        },
         "relateurl": {
           "version": "0.2.6"
         }

--- a/package.js
+++ b/package.js
@@ -8,10 +8,16 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "compileNGTemplate",
   sources: [
+    "plugin/ng-caching-html-compiler.js",
+    "plugin/ng-html-scanner.js",
     "plugin/ng-template-compiler.js"
   ],
   use: [
-    'html-tools@1.0.4'
+    'caching-html-compiler',
+    'ecmascript',
+    'templating-tools',
+    'underscore',
+    'html-tools'
   ],
   npmDependencies : {
     'cheerio': '0.19.0',

--- a/plugin/ng-caching-html-compiler.js
+++ b/plugin/ng-caching-html-compiler.js
@@ -1,0 +1,31 @@
+NgCachingHtmlCompiler = class NgCachingHtmlCompiler extends CachingHtmlCompiler {
+  compileOneFile(inputFile) {
+    const contents = inputFile.getContentsAsString();
+    var packagePrefix = '';
+
+    if (inputFile.getPackageName()) {
+      packagePrefix += inputFile.getPackageName() + '/';
+    }
+
+    const inputPath = packagePrefix + inputFile.getPathInPackage();
+    try {
+      const tags = this.tagScannerFunc({
+        sourceName: inputPath,
+        contents: contents,
+        tagNames: ["body", "head", "template"]
+      });
+
+      return this.tagHandlerFunc(tags);
+    } catch (e) {
+      if (e instanceof TemplatingTools.CompileError) {
+        inputFile.error({
+          message: e.message,
+          line: e.line
+        });
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/plugin/ng-html-scanner.js
+++ b/plugin/ng-html-scanner.js
@@ -1,0 +1,195 @@
+scanHtmlForTags = function (options) {
+  const scan = new HtmlScan(options);
+  return scan.getTags();
+};
+
+/**
+ * Scan an HTML file for top-level tags and extract their contents. Pass them to
+ * a tag handler (an object with a handleTag method)
+ *
+ * This is a primitive, regex-based scanner.  It scans
+ * top-level tags, which are allowed to have attributes,
+ * and ignores top-level HTML comments.
+ */
+class HtmlScan {
+  /**
+   * Initialize and run a scan of a single file
+   * @param  {String} sourceName The filename, used in errors only
+   * @param  {String} contents   The contents of the file
+   * @param  {String[]} tagNames An array of tag names that are accepted at the
+   * top level. If any other tag is encountered, an error is thrown.
+   */
+  constructor({
+    sourceName,
+    contents,
+    tagNames
+    }) {
+    this.sourceName = sourceName;
+    this.contents = contents;
+    this.tagNames = tagNames;
+
+    this.rest = contents;
+    this.index = 0;
+
+    this.tags = [];
+
+    tagNameRegex = this.tagNames.join("|");
+    const openTagRegex = new RegExp(`^((<(${tagNameRegex})\\b)|(<!--)|(<!DOCTYPE|{{!)|$)`, "i");
+
+    var foundMatch = false;
+    var nonMatchingTagsFound = false;
+
+    while (this.rest) {
+      // skip whitespace first (for better line numbers)
+      this.advance(this.rest.match(/^\s*/)[0].length);
+
+      const match = openTagRegex.exec(this.rest);
+
+      if (! match) {
+        nonMatchingTagsFound = true;
+        break;
+      }
+
+      foundMatch = true;
+
+      const matchToken = match[1];
+      const matchTokenTagName =  match[3];
+      const matchTokenComment = match[4];
+      const matchTokenUnsupported = match[5];
+
+      const tagStartIndex = this.index;
+      this.advance(match.index + match[0].length);
+
+      if (! matchToken) {
+        break; // matched $ (end of file)
+      }
+
+      if (matchTokenComment === '<!--') {
+        // top-level HTML comment
+        const commentEnd = /--\s*>/.exec(this.rest);
+        if (! commentEnd)
+          this.throwCompileError("unclosed HTML comment in template file");
+        this.advance(commentEnd.index + commentEnd[0].length);
+        continue;
+      }
+
+      if (matchTokenUnsupported) {
+        switch (matchTokenUnsupported.toLowerCase()) {
+          case '<!doctype':
+            this.throwCompileError(
+              "Can't set DOCTYPE here.  (Meteor sets <!DOCTYPE html> for you)");
+          case '{{!':
+            this.throwCompileError(
+              "Can't use '{{! }}' outside a template.  Use '<!-- -->'.");
+        }
+
+        this.throwCompileError();
+      }
+
+      // otherwise, a <tag>
+      const tagName = matchTokenTagName.toLowerCase();
+      const tagAttribs = {}; // bare name -> value dict
+      const tagPartRegex = /^\s*((([a-zA-Z0-9:_-]+)\s*=\s*(["'])(.*?)\4)|(>))/;
+
+      // read attributes
+      let attr;
+      while ((attr = tagPartRegex.exec(this.rest))) {
+        const attrToken = attr[1];
+        const attrKey = attr[3];
+        let attrValue = attr[5];
+        this.advance(attr.index + attr[0].length);
+
+        if (attrToken === '>') {
+          break;
+        }
+
+        // XXX we don't HTML unescape the attribute value
+        // (e.g. to allow "abcd&quot;efg") or protect against
+        // collisions with methods of tagAttribs (e.g. for
+        // a property named toString)
+        attrValue = attrValue.match(/^\s*([\s\S]*?)\s*$/)[1]; // trim
+        tagAttribs[attrKey] = attrValue;
+      }
+
+      if (! attr) { // didn't end on '>'
+        this.throwCompileError("Parse error in tag");
+      }
+
+      // find </tag>
+      const end = (new RegExp('</'+tagName+'\\s*>', 'i')).exec(this.rest);
+      if (! end) {
+        this.throwCompileError("unclosed <"+tagName+">");
+      }
+
+      const tagContents = this.rest.slice(0, end.index);
+      const contentsStartIndex = this.index;
+
+      // trim the tag contents.
+      // this is a courtesy and is also relied on by some unit tests.
+      var m = tagContents.match(/^([ \t\r\n]*)([\s\S]*?)[ \t\r\n]*$/);
+      const trimmedContentsStartIndex = contentsStartIndex + m[1].length;
+      const trimmedTagContents = m[2];
+
+      const tag = {
+        tagName: tagName,
+        attribs: tagAttribs,
+        contents: trimmedTagContents,
+        contentsStartIndex: trimmedContentsStartIndex,
+        tagStartIndex: tagStartIndex,
+        fileContents: this.contents,
+        sourceName: this.sourceName
+      };
+
+      // save the tag
+      this.tags.push(tag);
+
+      // advance afterwards, so that line numbers in errors are correct
+      this.advance(end.index + end[0].length);
+    }
+
+    if (!foundMatch) {
+      this.tags.push({
+        tagName : 'template',
+        attribs: {
+          id : this.sourceName
+        },
+        contents : this.contents,
+        contentsStartIndex: 1,
+        tagStartIndex: 1,
+        fileContents: this.contents,
+        sourceName: this.sourceName
+      })
+    }
+    else if (nonMatchingTagsFound) {
+      console.log('WARNING: ' + this.sourceName + ' A tag that is not of ' + tagNames.join(', ') + ' was found in a file that contains at least one of those, and will be ignored');
+    }
+  }
+
+  /**
+   * Advance the parser
+   * @param  {Number} amount The amount of characters to advance
+   */
+  advance(amount) {
+    this.rest = this.rest.substring(amount);
+    this.index += amount;
+  }
+
+  throwCompileError(msg, overrideIndex) {
+    const finalIndex = (typeof overrideIndex === 'number' ? overrideIndex : this.index);
+
+    const err = new TemplatingTools.CompileError();
+    err.message = msg || "bad formatting in template file";
+    err.file = this.sourceName;
+    err.line = this.contents.substring(0, finalIndex).split('\n').length;
+
+    throw err;
+  }
+
+  throwBodyAttrsError(msg) {
+    this.parseError(msg);
+  }
+
+  getTags() {
+    return this.tags;
+  }
+}


### PR DESCRIPTION
This PR uses Meteor's own code for searching for html templates in the code, and then adds them to angular's template cache.
Head and Body tags go to their matching places, and template tags go into the template cache by the id used on the template tag. for example:
`<template id="my-template.html">`
would add a my-template.html template to the $templateCache.

First level tags, that are not body or head or template that are found in files that do contain those are ignored. Files that contain non of those tags are added to the template cache by using the files location in the project. Files that are inside package are added to the template cache with this path: 'PACKAGE_NAME/PATH_IN_PACKAGE'.
