### PR TITLE
Splice removed elements from an array on diffArray.deepCopyRemovals()

### DIFF
--- a/lib/diff-array.js
+++ b/lib/diff-array.js
@@ -156,7 +156,8 @@ module.factory('diffArray', ['getUpdates',
         return subObj[k];
       }, obj);
 
-      getDeep(obj, initialKeys)[lastKey] = v;
+      var deepObj = getDeep(obj, initialKeys);
+      deepObj[lastKey] = v;
       return v;
     };
 
@@ -164,7 +165,12 @@ module.factory('diffArray', ['getUpdates',
       var split = deepKey.split('.');
       var initialKeys = _.initial(split);
       var lastKey = _.last(split);
-      return delete getDeep(obj, initialKeys)[lastKey];
+      var deepObj = getDeep(obj, initialKeys);
+
+      if (_.isArray(deepObj) && isNumStr(lastKey))
+        return !!deepObj.splice(lastKey, 1);
+      else
+        return delete deepObj[lastKey];
     };
 
     var getDeep = function(obj, keys) {

--- a/tests/integration/angular-meteor-diff-array-spec.js
+++ b/tests/integration/angular-meteor-diff-array-spec.js
@@ -230,6 +230,13 @@ describe('diffArray module', function() {
 
         expect(oldItem).toEqual(oldItemBefore);
       });
+
+      it('should splice removed elements from an array', function() {
+        var oldItem = {_id: 1, arr: [1, 2, 3]};
+        var newItem = {_id: 1, arr: [1, 2]};
+        deepCopyRemovals(oldItem, newItem);
+        expect(oldItem).toEqual(newItem);
+      });
     });
 
     describe('deepCopyChanges', function() {


### PR DESCRIPTION
Originaly created to fix [this](https://github.com/roeeyud/angular-meteor-watching-array-bug) issue.