### PR TITLE
Fixed: `app.ng.js` file being called `app.js`

### DIFF
--- a/.docs/angular-meteor/client/content/tutorials/angular1/steps/tutorial.step_05.md
+++ b/.docs/angular-meteor/client/content/tutorials/angular1/steps/tutorial.step_05.md
@@ -18,7 +18,7 @@ Type in the command line:
 
     meteor add angularui:angular-ui-router
 
-Then add the ui-router as a dependency to our angular app in `app.js`:
+Then add the ui-router as a dependency to our angular app in `app.ng.js`:
 
 {{> DiffBox tutorialName="angular-meteor" step="5.2"}}
 
@@ -76,7 +76,7 @@ This code can serve as a placeholder for now. We'll get back to filling out the 
 # Routes definition
 
 Now let's configure our routes.
-Add this config code in `app.js`, after the Angular 1 app has been defined:
+Add this config code in `app.ng.js`, after the Angular 1 app has been defined:
 
 {{> DiffBox tutorialName="angular-meteor" step="5.7"}}
 


### PR DESCRIPTION
Fix to two instances where the `app.ng.js` was being called `app.js` outside the code snippets.

The `app.js` file was renamed to `app.ng.js` at tutorial step 2.4.