### PR TITLE
Mention how to add "account-password" package

### DIFF
--- a/.docs/angular-meteor/client/content/api/api.auth.html
+++ b/.docs/angular-meteor/client/content/api/api.auth.html
@@ -11,7 +11,9 @@
 # Accounts, users and authentication
 
 Methods and [$rootScope](https://docs.angularjs.org/api/ng/service/$rootScope) variables to support [Meteor.user](http://docs.meteor.com/#/full/meteor_user) and [Meteor's accounts system](http://docs.meteor.com/#/full/accounts_api)
+.Need to add the meteor package by following command on terminal
 
+`meteor add accounts-password`
 ----
 
 ## Usage


### PR DESCRIPTION
I think somewhere in description it should be mentioned to how to add the accounts-password package
"meteor add accounts-password"