### PR TITLE
Fix "main" path in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-meteor",
-  "main": "./.dist/angular-meteor.bundle.min.js",
+  "main": "./dist/angular-meteor.bundle.min.js",
   "version": "1.2.0",
   "homepage": "https://github.com/Urigo/angular-meteor",
   "authors": [


### PR DESCRIPTION
The `main` field in bower.json refers to a non-existent directory. This prevents tools like [main-bower-files](https://www.npmjs.com/package/main-bower-files) from working correctly. This PR fixes that field to point to the main script in the `dist/` directory.