### PR TITLE
Include file path in the cache key of NgCachingHtmlCompiler

### DIFF
--- a/docs/angular-meteor/packages/tutorial-step-diff-compiler/.npm_old/plugin/mdg:tutorial-step-diffs-plugin/.gitignore
+++ b/docs/angular-meteor/packages/tutorial-step-diff-compiler/.npm_old/plugin/mdg:tutorial-step-diffs-plugin/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/docs/angular-meteor/packages/tutorial-step-diff-compiler/.npm_old/plugin/mdg:tutorial-step-diffs-plugin/README
+++ b/docs/angular-meteor/packages/tutorial-step-diff-compiler/.npm_old/plugin/mdg:tutorial-step-diffs-plugin/README
@@ -1,7 +1,0 @@
-This directory and the files immediately inside it are automatically generated
-when you change this package's NPM dependencies. Commit the files in this
-directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
-so that others run the same versions of sub-dependencies.
-
-You should NOT check in the node_modules directory that Meteor automatically
-creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/docs/angular-meteor/packages/tutorial-step-diff-compiler/.npm_old/plugin/mdg:tutorial-step-diffs-plugin/npm-shrinkwrap.json
+++ b/docs/angular-meteor/packages/tutorial-step-diff-compiler/.npm_old/plugin/mdg:tutorial-step-diffs-plugin/npm-shrinkwrap.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "am-git-patch-parser": {
-      "version": "0.2.1"
-    }
-  }
-}

--- a/packages/angular-templates/plugin/ng-caching-html-compiler.js
+++ b/packages/angular-templates/plugin/ng-caching-html-compiler.js
@@ -3,6 +3,7 @@ NgCachingHtmlCompiler = class NgCachingHtmlCompiler extends CachingHtmlCompiler 
   getCacheKey(inputFile) {
     // Note: we include the path for files that are renamed
     return [
+      inputFile.getPackageName(),
       inputFile.getPathInPackage(),
       inputFile.getSourceHash()
     ];

--- a/packages/angular-templates/plugin/ng-caching-html-compiler.js
+++ b/packages/angular-templates/plugin/ng-caching-html-compiler.js
@@ -1,4 +1,13 @@
 NgCachingHtmlCompiler = class NgCachingHtmlCompiler extends CachingHtmlCompiler {
+
+  getCacheKey(inputFile) {
+    // Note: we include the path for files that are renamed
+    return [
+      inputFile.getPathInPackage(),
+      inputFile.getSourceHash()
+    ];
+  }
+  
   compileOneFile(inputFile) {
     const contents = inputFile.getContentsAsString();
     var packagePrefix = '';


### PR DESCRIPTION
Fixes https://github.com/Urigo/angular-meteor/issues/888

Note that I can't seem to clone or commit without deleting these files in `.npm_old`, git gives me all kinds of erros.