### PR TITLE
Adding blaze-html-templates as a dependency to angular-with-blaze

### DIFF
--- a/packages/angular-with-blaze/package.js
+++ b/packages/angular-with-blaze/package.js
@@ -8,8 +8,10 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.2.0.1');
+  api.use('blaze-html-templates', 'client');
 
   api.imply([
+    'blaze-html-templates',
     'angular-meteor-data@0.0.7',
     'angular-blaze-templates-compiler@0.0.1'
   ])


### PR DESCRIPTION
replaces Urigo/angular-blaze-template#8

should also fix Urigo/angular-blaze-template#10