### PR TITLE
(bugfix) Fix subscription call, used apply with the context

### DIFF
--- a/packages/angular-meteor-data/modules/angular-meteor-reactive-context.js
+++ b/packages/angular-meteor-data/modules/angular-meteor-reactive-context.js
@@ -216,7 +216,7 @@ angular.module('angular-meteor.reactive', ['angular-meteor.reactive-scope']).fac
       }
       else {
         let autorunComp = this.autorun(() => {
-          let args = fn() || [];
+          let args = fn.apply(this.context) || [];
           if (!angular.isArray(args)) {
             throw new Error(`[angular-meteor][ReactiveContext] The return value of arguments function in subscribe must be an array! `);
           }

--- a/packages/angular-meteor-data/modules/angular-meteor-reactive-scope.js
+++ b/packages/angular-meteor-data/modules/angular-meteor-reactive-scope.js
@@ -15,7 +15,7 @@ angularMeteorReactiveScope.run(['$rootScope', '$reactive', '$parse', function ($
     subscribe (name, fn = angular.noop, resultCb) {
       let result = {};
       let autorunComp = this.autorun(() => {
-        let args = fn() || [];
+        let args = fn().apply(this) || [];
         if (!angular.isArray(args)) {
           throw new Error(`[angular-meteor][ReactiveContext] The return value of arguments function in subscribe must be an array! `);
         }

--- a/packages/angular-meteor-data/modules/angular-meteor-reactive-scope.js
+++ b/packages/angular-meteor-data/modules/angular-meteor-reactive-scope.js
@@ -15,7 +15,7 @@ angularMeteorReactiveScope.run(['$rootScope', '$reactive', '$parse', function ($
     subscribe (name, fn = angular.noop, resultCb) {
       let result = {};
       let autorunComp = this.autorun(() => {
-        let args = fn().apply(this) || [];
+        let args = fn.apply(this) || [];
         if (!angular.isArray(args)) {
           throw new Error(`[angular-meteor][ReactiveContext] The return value of arguments function in subscribe must be an array! `);
         }

--- a/packages/angular-meteor-data/tests/integration/angular-meteor-reactive-context.spec.js
+++ b/packages/angular-meteor-data/tests/integration/angular-meteor-reactive-context.spec.js
@@ -666,6 +666,15 @@ describe('angular-meteor', function () {
 
         expect(subscribeSpy).toHaveBeenCalledWith('test', 10, 20, cb);
       });
+
+      it('Should call the subscription method with the correct context', function (done) {
+        $reactive(context);
+
+        context.subscribe('test', function () {
+          expect(this).toBe(context);
+          done();
+        });
+      });
     });
   });
 });

--- a/packages/angular-meteor-data/tests/integration/angular-meteor-reactive-scope.spec.js
+++ b/packages/angular-meteor-data/tests/integration/angular-meteor-reactive-scope.spec.js
@@ -191,7 +191,14 @@ describe('angular-meteor', function () {
       testScope.subscribe('test');
 
       expect(meteorSubscribeSpy).toHaveBeenCalledWith('test', undefined);
-    })
+    });
+
+    it('Should call the subscribe method with the correct context', function (done) {
+      testScope.subscribe('test', function() {
+        expect(this).toBe(testScope);
+        done();
+      });
+    });
 
     it('Should call stop method of autorun when destroying the scope', function() {
       var stoppableSpy = jasmine.createSpy('stop');


### PR DESCRIPTION
@Urigo 

Fixed in order to provide this logic:
```js
class myComponent {
   constructor() {
      this.subscribe('name', this.fn); // now the call to that fn will be with the correct context 
   }

   fn() {
      return [10, 20, 30];
   }
}
```