### PR TITLE
changed anguluar-meteor.com urls to use http since https not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 ## Getting started with Angular Meteor
 
-[Getting started tutorial](https://angular-meteor.com/tutorial)
+[Getting started tutorial](http://angular-meteor.com/tutorial)
 
 ## Documentation
-- [Official website](https://angular-meteor.com)
+- [Official website](http://angular-meteor.com)
 - [Example application](https://github.com/Urigo/meteor-angular-socially) (Final version of the tutorial)
 - Questions and help - [stack-overflow `angular-meteor` tag](http://stackoverflow.com/questions/tagged/angular-meteor)
 - [Discussions - the Meteor Forum](https://forums.meteor.com/)
@@ -40,7 +40,7 @@ We would love contributions in:
 1. Code - We would love to get your pull requests, just don't forget the tests..
 2. [Tutorial](http://angular-meteor.com/tutorial) - our goal with the tutorial is to add as many common use cases as possible. If you want to create and add your own chapter we would be happy to help you writing and adding it. Also if you want to record a video for a chapter we would love to help you.
 3. [Roadmap](https://trello.com/b/Wj9U0ulk/angular-meteor) - you can add a card about what you want to see in the library or in the tutorial.
-4. I ([Urigo](https://github.com/urigo)) live around the world with one small bag, so another way of contributing can be by offering me a place to sleep somewhere interesting around the world that I have to see :) 
+4. I ([Urigo](https://github.com/urigo)) live around the world with one small bag, so another way of contributing can be by offering me a place to sleep somewhere interesting around the world that I have to see :)
 
 If you want to contribute and need help or don't know what should you do, you can [contact me directly](https://github.com/urigo)
 

--- a/docs/angular-meteor/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_14.md
+++ b/docs/angular-meteor/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_14.md
@@ -57,6 +57,18 @@ Let's add that permission to the publish parties method:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="14.6"}}
 
+### Serve Email
+
+NOTE: If you want to test email functionality locally with your own gmail account, create a new file called `environments.js` in the `server/startup/` directory. Add the following lines substituting [YOUR_EMAIL] and [YOUR_PASSWORD].  
+
+    Meteor.startup(function () {
+        process.env.MAIL_URL="smtp://[YOUR_EMAIL]@gmail.com:[YOUR_PASSWORD]@smtp.gmail.com:465/";
+    })
+
+You may need to set your gmail account to use [Less Secure Apps](https://www.google.com/settings/u/2/security/lesssecureapps).
+
+In production you could use a service like Mandrill with this [Meteor Mandrill Package](https://atmospherejs.com/wylio/mandrill).
+
 Great!
 
 Now test the app.  Create a private party with user1.  Then invite user2. Log in as user2 and check if he can see the party in his own parties list.


### PR DESCRIPTION
To eliminate frustration for new visitors, fixed the angular-meteor.com urls to point to http instead of https. The https calls are not resolving. 