### PR TITLE
chore(npm): build before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "watch": "webpack --watch --progress --config webpack/dist.js",
     "build:dist": "webpack --progress --config webpack/dist.js",
     "build:prod": "webpack --progress --config webpack/prod.js --optimize-minimize",
-    "build": "npm run build:dist && npm run build:prod"
+    "build": "npm run build:dist && npm run build:prod",
+    "prepublish": "npm run build"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
@Urigo You're asking me about it, here's simple solution :)

You don't have to run `npm run build` on every time you want to publish new release.