### PR TITLE
chore(changelog): auto-changelog generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "license": "MIT",
   "scripts": {
+    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",
     "lint": "eslint .",
@@ -38,6 +39,7 @@
     "babel-loader": "^6.2.1",
     "babel-preset-es2015": "^6.3.13",
     "commitizen": "^2.5.0",
+    "conventional-changelog-cli": "^1.1.1",
     "cz-conventional-changelog": "^1.1.5",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^4.0.0",


### PR DESCRIPTION
Closes #1210 

To generate the changelog of the new release, you have to run:

```
npm run changelog
```

I could make that changelog would be generated right before publishing new version but I think it's better to run it manually so you can check everything.

---

To create a whole new changelog, including very previous changes, use:

```
conventional-changelog -p angular -i CHANGELOG.md -s -r 0
```
