### PR TITLE
commonjs support for es6 modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-core": "^6.4.5",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.1",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.3.13",
     "commitizen": "^2.5.0",
     "conventional-changelog-cli": "^1.1.1",

--- a/src/angular-meteor.js
+++ b/src/angular-meteor.js
@@ -23,7 +23,8 @@ import { name as viewModelName, ViewModel } from './modules/view-model';
 import { name as reactiveName, Reactive } from './modules/reactive';
 import { name as templatesName } from './modules/templates';
 
-export const name = 'angular-meteor';
+const name = 'angular-meteor';
+export default name;
 
 angular.module(name, [
   // new

--- a/webpack/common.js
+++ b/webpack/common.js
@@ -11,8 +11,11 @@ var common = {
   },
   output: {
     // point to root directory so we can avoid using ../../
-    path: path.join(__dirname, '../')
+    path: path.join(__dirname, '../'),
+    library: 'angularMeteor',
+    libraryTarget: 'umd'
   },
+  target: 'web',
   // global variables
   externals: {
     angular: 'angular',
@@ -24,7 +27,8 @@ var common = {
   },
   // global configuration of babel loader
   babel: {
-    presets: ['es2015']
+    presets: ['es2015'],
+    plugins: ['add-module-exports']
   },
   eslint: {
     quiet: true,


### PR DESCRIPTION
It can be used like that:

```javascript
import angular from 'angular';
import angularMeteor from 'angular-meteor';

angular.module('app', [
    angularMeteor
]);
```