### PR TITLE
test(reactive): helpers should not invoke on observation update

### DIFF
--- a/tests/integration/reactive.spec.js
+++ b/tests/integration/reactive.spec.js
@@ -389,6 +389,29 @@ describe('angular-meteor.reactive', function() {
         expect(callCount).toBe(2);
       });
 
+      it('should NOT invoke the reactive function when internal observation updates', function () {
+        let callCount = 0;
+        vm.helpers({
+          parties() {
+            callCount++;
+            return DummyCollection.find({});
+          }
+        });
+
+        scope.$apply();
+        Tracker.flush();
+
+        DummyCollection.insert({
+          name: 'foo'
+        });
+
+        scope.$apply();
+        Tracker.flush();
+
+        expect(callCount).toEqual(1);
+        expect(vm.parties.length).toEqual(1);
+      });
+
       it('should be able to register view model and scope helpers at the same time', function() {
         scope.helpers({
           parties() { return DummyCollection.find({}); }


### PR DESCRIPTION
- [x] Test the new autorun change. Make sure that when the cursor update internally (addedAt, changedAt etc...) The autorun doesn't run.