### PR TITLE
chore: use underscore dependency

### DIFF
--- a/src/lib/diff-array.js
+++ b/src/lib/diff-array.js
@@ -2,6 +2,8 @@
  angular, _, Package
  */
 
+import _ from './underscore';
+
 'use strict';
 
 var _module = angular.module('diffArray', ['getUpdates']);

--- a/src/lib/get-updates.js
+++ b/src/lib/get-updates.js
@@ -2,6 +2,8 @@
  angular, _
  */
 
+import _ from './underscore';
+
 'use strict';
 
 // https://github.com/DAB0mB/get-updates

--- a/src/lib/underscore.js
+++ b/src/lib/underscore.js
@@ -1,0 +1,9 @@
+import _ from 'underscore';
+
+if (typeof _ === 'undefined') {
+  if (typeof Package.underscore === 'undefined') {
+    throw new Error('underscore is missing');
+  }
+}
+
+export default _ || Package.underscore._;

--- a/src/modules/angular-meteor-collection.js
+++ b/src/modules/angular-meteor-collection.js
@@ -2,6 +2,8 @@
  angular, _, Tracker, check, Match, Mongo
  */
 
+import _ from '../lib/underscore';
+
 'use strict';
 
 var angularMeteorCollection = angular.module('angular-meteor.collection',

--- a/src/modules/angular-meteor-methods.js
+++ b/src/modules/angular-meteor-methods.js
@@ -2,6 +2,8 @@
  angular, _, Meteor
  */
 
+import _ from '../lib/underscore';
+
 'use strict';
 
 var angularMeteorMethods = angular.module('angular-meteor.methods', ['angular-meteor.utils', 'angular-meteor.settings']);

--- a/src/modules/angular-meteor-object.js
+++ b/src/modules/angular-meteor-object.js
@@ -2,6 +2,8 @@
   angular, _, Mongo
 */
 
+import _ from '../lib/underscore';
+
 'use strict';
 
 var angularMeteorObject = angular.module('angular-meteor.object',

--- a/src/modules/angular-meteor-user.js
+++ b/src/modules/angular-meteor-user.js
@@ -2,6 +2,8 @@
  angular, _, Package, Meteor
  */
 
+import _ from '../lib/underscore';
+
 'use strict';
 
 var angularMeteorUser = angular.module('angular-meteor.user', [

--- a/src/modules/angular-meteor-utils.js
+++ b/src/modules/angular-meteor-utils.js
@@ -2,6 +2,8 @@
  angular, _, Tracker, EJSON, FS, Mongo
  */
 
+import _ from '../lib/underscore';
+
 'use strict';
 
 var angularMeteorUtils = angular.module('angular-meteor.utils', ['angular-meteor.settings']);

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1,3 +1,4 @@
+import _ from '../lib/underscore';
 import { name as utilsName, utils } from './utils';
 import { name as mixerName, Mixer } from './mixer';
 

--- a/src/modules/mixer.js
+++ b/src/modules/mixer.js
@@ -1,3 +1,5 @@
+import _ from '../lib/underscore';
+
 export const name = 'angular-meteor.mixer';
 export const Mixer = '$Mixer';
 

--- a/src/modules/reactive.js
+++ b/src/modules/reactive.js
@@ -1,3 +1,5 @@
+import jsondiffpatch from 'jsondiffpatch';
+import _ from '../lib/underscore';
 import { name as utilsName, utils } from './utils';
 import { name as mixerName, Mixer } from './mixer';
 import { name as coreName } from './core';

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -1,3 +1,5 @@
+import _ from '../lib/underscore';
+
 export const name = 'angular-meteor.utilities';
 export const utils = '$$utils';
 

--- a/src/modules/view-model.js
+++ b/src/modules/view-model.js
@@ -1,3 +1,4 @@
+import _ from '../lib/underscore';
 import { name as utilsName, utils } from './utils';
 import { name as mixerName, Mixer } from './mixer';
 import { name as coreName } from './core';

--- a/webpack/common.js
+++ b/webpack/common.js
@@ -20,7 +20,12 @@ var common = {
   externals: {
     angular: 'angular',
     jsondiffpatch: 'jsondiffpatch',
-    '_': 'underscore',
+    underscore: {
+      root: '_',
+      amd: 'underscore',
+      commonjs2: 'underscore',
+      commonjs: 'underscore'
+    },
     Meteor: 'Meteor',
     Package: 'Package',
     Tracker: 'Tracker'
@@ -50,11 +55,7 @@ var common = {
   },
   plugins: [
     // add information about name and version of angular-meteor package
-    new webpack.BannerPlugin(pkg.name + ' v' + pkg.version),
-    new webpack.ProvidePlugin({
-      '_': 'underscore',
-      'jsondiffpatch': 'jsondiffpatch'
-    })
+    new webpack.BannerPlugin(pkg.name + ' v' + pkg.version)
   ],
   resolve: {
     extensions: ['', '.js']


### PR DESCRIPTION
**Before**:

We were using global `_` variable so it might be causing few errors when there is no `underscore` package in meteor app.

**Now**:

We're importing `underscore` instead of using global object.

I made webpack to be compatible with global variables (`root`), amd, commonjs2 and commonjs.

```javascript
underscore: {
    root: '_', // this looks for underscore in global window object
    amd: 'underscore',
    commonjs2: 'underscore',
    commonjs: 'underscore'
},
```

But `underscore` in meteor world is not a global variable but it's under package scope as local variable.

I had to fix it somehow, you can check it  in `src/lib/underscore.js`.

@Urigo