### PR TITLE
Update docs: running locally

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,17 +12,17 @@ today! Here are the guidelines we'd like you to follow:
  - [Commit Message Guidelines](#commit)
 
 ## <a name="coc"></a> Code of Conduct
-I love the Angular community so let's just use thier [Code of Conduct][https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md].
+I love the Angular community so let's just use thier [Code of Conduct](https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md).
 
 If you are subject to or witness unacceptable behavior, or have any other concerns, please email me at uri.goldshtein@gmail.com.
 
 ## <a name="question"></a> Got a Question or Problem?
 
-If you have questions about how to use Angular Meteor, please direct these to [StackOverflow][http://stackoverflow.com/questions/tagged/angular-meteor] or the [Meteor forums](https://forums.meteor.com/).
+If you have questions about how to use Angular Meteor, please direct these to [StackOverflow](http://stackoverflow.com/questions/tagged/angular-meteor) or the [Meteor forums](https://forums.meteor.com/).
 
 ## <a name="issue"></a> Found an Issue?
 If you find a bug in the source code or a mistake in the documentation, you can help us by
-submitting an issue to our [GitHub Repository][https://github.com/urigo/angular-meteor/]. Even better you can submit a Pull Request
+submitting an issue to our [GitHub Repository](https://github.com/urigo/angular-meteor/). Even better you can submit a Pull Request
 with a fix.
 
 ## <a name="feature"></a> Want a Feature?
@@ -79,18 +79,44 @@ It is a step by step process.
 
 ## Run local angular-meteor in your project
 
-Create your Meteor Project
+### Meteor 1.2
 
 ```bash
 meteor create myProject
-cd myProject
 ```
 
 Create a `packages` directory under your project's root folder and link your forked repo
 
 ```bash
 cd myProject
-ln -s ~/path_to_your_repos/angular/packages/
+ln -s ~/path_to_your_repos/angular-meteor/packages/
+```
+
+The `angular-meteor-data` package uses a node module.
+
+All you have to do is to change it in `package.js`:
+
+```javascript
+api.add_files([
+  // '.npm/package/node_modules/angular-meteor/dist/angular-meteor.js'
+  'angular-meteor.js'
+], 'client', {
+  transpile: false
+});
+```
+
+As you can see, there is no `angular-meteor.js` file.
+
+You can build this file by running:
+
+```bash
+npm run build:dev
+```
+
+If you don’t want to manually recompile after every change you can use watch mode.
+
+```bash
+npm run watch:dev
 ```
 
 Now you can start using your own copy of the `angular-meteor` project from `myProject`.
@@ -98,6 +124,7 @@ Now you can start using your own copy of the `angular-meteor` project from `myPr
 ## Running tests
 
 In the command line
+
 ```
 npm run test:watch
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,6 +79,45 @@ It is a step by step process.
 
 ## Run local angular-meteor in your project
 
+### Meteor 1.3
+
+```bash
+meteor create myProject
+```
+
+Install `angular-meteor` for your application.
+
+```bash
+npm install angular-meteor --save
+```
+
+Create a globally-installed symbolic link to your forked repository.
+
+```bash
+cd /path_to_your_repos/angular-meteor/
+npm link
+```
+
+Now create a symlink from the local node_modules folder to the global symlink
+
+```bash
+cd myProject
+npm link angular-meteor
+```
+
+You can compile `angular-meteor` by running:
+
+```bash
+npm run build
+```
+
+If you don’t want to manually recompile after every change you can use watch mode.
+
+```bash
+npm run watch
+```
+
+
 ### Meteor 1.2
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "test": "velocity test-packages ./tests --ci",
     "test:watch": "parallelshell \"npm run watch\" \"velocity test-packages ./tests\"",
     "watch": "webpack --watch --progress --config webpack/dist.js",
+    "watch:dev": "webpack --watch --progress --config webpack/dev.js",
     "build:dist": "webpack --progress --config webpack/dist.js",
+    "build:dev": "webpack --progress --config webpack/dev.js",
     "build:prod": "webpack --progress --config webpack/prod.js --optimize-minimize",
     "build": "npm run build:dist && npm run build:prod",
     "prepublish": "npm run build"

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -1,0 +1,8 @@
+module.exports = require('./common')({
+  entry: {
+    'packages/angular-meteor-data/angular-meteor': './src/angular-meteor'
+  },
+  output: {
+    filename: '[name].js'
+  }
+});


### PR DESCRIPTION
`npm link` and `npm run watch` is amazing to use :smiley:

Cotributor won't have to recompile `angular-meteor` or rerun meteor app.


The same thing with symlink and `npm run watch:dev` in Meteor 1.2.

---

Closes: #1288 