### PR TITLE
chore(angular-meteor-data): use node module without ecmascript

### DIFF
--- a/packages/angular-meteor-data/package.js
+++ b/packages/angular-meteor-data/package.js
@@ -5,6 +5,10 @@ Package.describe({
   git: 'https://github.com/Urigo/angular-meteor.git'
 });
 
+Npm.depends({
+  'angular-meteor': '1.3.9'
+});
+
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.2.0.1');
 
@@ -21,14 +25,13 @@ Package.onUse(function (api) {
   api.use('mongo@1.1.1');
   api.use('minimongo@1.0.9');
   api.use('observe-sequence@1.0.7');
-  api.use('ecmascript');
   api.use('reactive-var');
   api.use('benjamine:jsondiffpatch@0.1.38_1');
   api.use('angular:angular@1.4.8', 'client');
   api.use('isobuild:compiler-plugin@1.0.0');
 
   api.add_files([
-    'angular-meteor.js'
+    '.npm/package/node_modules/angular-meteor/dist/angular-meteor.js'
   ], 'client', {
     transpile: false
   });


### PR DESCRIPTION
before:

```javascript
var require = meteorInstall({"node_modules":{"meteor":{"angular-meteor-data":{"angular-meteor.js":function(require,exports,module){

/*! angular-meteor v1.3.9 */
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory(require("underscore"), require("jsondiffpatch"));
	else if(typeof define === 'function' && define.amd)
		define(["underscore", "jsondiffpatch"], factory);
	else if(typeof exports === 'object')
		exports["angularMeteor"] = factory(require("underscore"), require("jsondiffpatch"));
	else
		root["angularMeteor"] = factory(root["_"], root["jsondiffpatch"]);
})

// ...
```

after:

```javascript
(function(){

/*! angular-meteor v1.3.9 */
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory(require("underscore"), require("jsondiffpatch"));
	else if(typeof define === 'function' && define.amd)
		define(["underscore", "jsondiffpatch"], factory);
	else if(typeof exports === 'object')
		exports["angularMeteor"] = factory(require("underscore"), require("jsondiffpatch"));
	else
		root["angularMeteor"] = factory(root["_"], root["jsondiffpatch"]);
})

// ...
```

As you can see, with `ecmascript`, package's code is being wrapped by `meteorInstall`.

Because of this and webpack's additional code it makes `angular-meteor` to use **commonjs** modules.

It's fine when `angular-meteor` is being used as a node module but it causing issues in `angular-meteor-data` package. This PR should fix this.