### PR TITLE
feat(templates): optional error and warning of missing template

### DIFF
--- a/packages/angular-templates/templates-handler.js
+++ b/packages/angular-templates/templates-handler.js
@@ -14,24 +14,36 @@ angular.module('angular-templates', []).config([
   function ($provide) {
     var templatesFileExtension = ['html', 'tpl', 'tmpl', 'template', 'view'];
 
-    $provide.decorator('$templateCache', ['$delegate', function($delegate) {
-      var originalGet = $delegate.get;
+    $provide.decorator('$templateCache', ['$delegate', '$angularTemplatesSettings',
+      function($delegate, $angularTemplatesSettings) {
+        var originalGet = $delegate.get;
 
-      $delegate.get = function(templatePath) {
-        var originalResult = originalGet(templatePath);
+        $delegate.get = function(templatePath) {
+          var originalResult = originalGet(templatePath);
 
-        if (angular.isUndefined(originalResult)) {
-          var fileExtension = ((templatePath.split('.') || []).pop() || '').toLowerCase();
+          if (angular.isUndefined(originalResult)) {
+            var fileExtension = ((templatePath.split('.') || []).pop() || '').toLowerCase();
 
-          if (templatesFileExtension.indexOf(fileExtension) > -1) {
-            throw new Error('[angular-meteor][err][404] ' + templatePath + ' - HTML template does not exists!');
+            if (templatesFileExtension.indexOf(fileExtension) > -1) {
+              function getMsg(type) {
+                return '[angular-meteor][err][404] ' + templatePath + ' - HTML template does not exists! You can disable this ' + type + ' by following this guide http://www.angular-meteor.com/api/1.3.11/templates';
+              }
+
+              if ($angularTemplatesSettings.error === true) {
+                throw new Error(getMsg('error'));
+              } else if ($angularTemplatesSettings.warning === true) {
+                console.warn(getMsg('warning'));
+              }
+            }
           }
-        }
 
-        return originalResult;
-      };
+          return originalResult;
+        };
 
-      return $delegate;
+        return $delegate;
     }]);
   }
-]);
+]).constant('$angularTemplatesSettings', {
+  error: true,
+  warning: true
+});;


### PR DESCRIPTION
## API

`$angularTemplatesSettings` constant as a plain object with two properties:

- `(boolean) error` - throws an error - *default: true*
- `(boolean) warning` - uses console.warn - *default: true*

Of course `error` overwrites `console.warn`.

## Use cases

If someone wants to avoid throwing errors he can simply set `error` to false and still he will see helpful warnings about missing template.

In different case, when user doesn't want to be notified, he can set both options to false.