### PR TITLE
refactor(templates): use exports.default with __esModule

### DIFF
--- a/packages/angular-templates-runtime/ng-template-compiler.js
+++ b/packages/angular-templates-runtime/ng-template-compiler.js
@@ -103,12 +103,14 @@ var minifyHtml = function(html) {
 
 function wrapAngularTemplate(templateUrl, contents) {
   return `
+  var templateUrl = "${templateUrl}";
   angular.module('angular-templates')
     .run(['$templateCache', function($templateCache) {
-      $templateCache.put('${templateUrl}', ${JSON.stringify(contents)});
+      $templateCache.put(templateUrl, ${JSON.stringify(contents)});
     }]);
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = "${templateUrl}";
+  if (typeof exports !== 'undefined') {
+    exports.__esModule = true;
+    exports.default = templateUrl;
   }
   `;
 }


### PR DESCRIPTION
```js
#
# Outdated
#
// before
import templateUrl from './template.html';
// after
import { templateUrl } from './template.html';
```

---

Restored previous behavior to export templateUrl by default and added space for additional variables.