### PR TITLE
fix(#1577): Prevent thi…

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -131,7 +131,12 @@ angular.module(name, [
         !this.$$phase &&
         !this.$root.$$phase;
 
-      if (isDigestable) this.$digest();
+      if (isDigestable) {
+        // If a digest cycle in one autorun triggers another autorun,
+        // we want to run this second autorun in a non-reactive manner.
+        // thus preventing inner autoruns from being dependent on their parents.
+        Tracker.nonreactive(() => this.$digest());
+      }
     };
 
     // Creates a promise only that the digestion cycle will be called at its fulfillment

--- a/tests/client/core.spec.js
+++ b/tests/client/core.spec.js
@@ -90,6 +90,20 @@ describe('angular-meteor.core', function() {
 
         expect(stop.calledOnce).to.be.true;
       });
+
+      it('should run digest in a non-reactive manner, so autoruns triggered by the digest are not dependent on other autoruns', function() {
+        scope.$watch('foo',function(val) {
+          if (val) {
+            var computation = scope.autorun(angular.noop);
+            expect(computation._parent).to.be.null;
+          }
+        });
+
+        scope.autorun(function() {
+          scope.foo = 'baz';
+        });
+       
+      });
     });
 
     describe('subscribe()', function() {


### PR DESCRIPTION
Fixes: https://github.com/Urigo/angular-meteor/issues/1577

An autorun function can trigger components being compiled and thus other autorun functions in those component controllers to be ran. Since this happens while the first autorun is running, these autorun functions think they are nested in the first autorun function.

As a result, when the parent autorun is invalidated, these child autorun functions are stopped and do not re-run in these scenarios. 

This change is probably the easiest way to fixing this. A better way might be to only run a digest cycle after the autorun function completes, but this would require a much bigger code change.

A side effect from this change is that if you actually want to have nested autoruns, you have to do it like this:

```js
this.autorun(() => {
 Tracker.autorun(() => {});
});
```

Instead of
```js
this.autorun(() => {
  this.autorun(() => {});
});
```
