### PR TITLE
switching angular2 references to angular

### DIFF
--- a/examples/angularcli-meteor/e2e/app.e2e-spec.ts
+++ b/examples/angularcli-meteor/e2e/app.e2e-spec.ts
@@ -11,4 +11,10 @@ describe('angularcli-meteor App', () => {
     page.navigateTo();
     expect(page.getParagraphText()).toEqual('Welcome to app!');
   });
+
+  it('should load chats from them Meteor backend', () => {
+    const chats = '[ { "title": "Ethan Gonzalez", "picture": "https://randomuser.me/api/portraits/thumb/men/1.jpg", "_id": "YHiPouKHn33TfvJ4N" }, { "title": "Bryan Wallace", "picture": "https://randomuser.me/api/portraits/thumb/lego/1.jpg", "_id": "QoPA22itTNmux82cj" }, { "title": "Avery Stewart", "picture": "https://randomuser.me/api/portraits/thumb/women/1.jpg", "_id": "4zN8GZc7cr68PibaD" }, { "title": "Katie Peterson", "picture": "https://randomuser.me/api/portraits/thumb/women/2.jpg", "_id": "yEroDzg5wCbdgDXFJ" }, { "title": "Ray Edwards", "picture": "https://randomuser.me/api/portraits/thumb/men/2.jpg", "_id": "pWJXJHhhrDxiyczrF" } ]';
+    page.navigateTo();
+    expect(page.getLastDiv()).toEqual(chats);
+  });
 });

--- a/examples/angularcli-meteor/e2e/app.po.ts
+++ b/examples/angularcli-meteor/e2e/app.po.ts
@@ -8,4 +8,8 @@ export class AppPage {
   getParagraphText() {
     return element(by.css('app-root h1')).getText();
   }
+
+  getLastDiv() {
+    return element(by.css('app-root div:last-child')).getText();
+  }
 }

--- a/examples/angularcli-meteor/karma.conf.js
+++ b/examples/angularcli-meteor/karma.conf.js
@@ -22,12 +22,22 @@ module.exports = function (config) {
     angularCli: {
       environment: 'dev'
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false
+    browsers: ['ChromeHeadlessNoSandbox'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox', // required to run without privileges in docker
+          '--user-data-dir=/tmp/chrome-test-profile',
+          '--disable-web-security'
+        ]
+      }
+    },
+    singleRun: true
   });
 };

--- a/examples/angularcli-meteor/protractor.conf.js
+++ b/examples/angularcli-meteor/protractor.conf.js
@@ -9,7 +9,10 @@ exports.config = {
     './e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    'browserName': 'chrome',
+    chromeOptions: {
+      args: [ '--headless', '--no-sandbox', '--disable-gpu', '--window-size=800x600' ]
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',

--- a/examples/angularcli-meteor/src/test.ts
+++ b/examples/angularcli-meteor/src/test.ts
@@ -11,6 +11,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import 'meteor-client';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare const __karma__: any;


### PR DESCRIPTION
I found several references to packages outside of this repository, like [angular2-runtime](https://atmospherejs.com/barbatus/angular2-runtime) and [angular2-meteor-polyfills](https://github.com/barbatus/angular2-meteor-polyfills). I left them untouched.
This repo has `angular2-polyfills` which may be or not be the equivalent of `angular2-meteor-polyfills`. Better be safe for the moment.