### PR TITLE
chore(renovate): remove unnecessary meteor enablement

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["config:js-lib", ":meteor"]
+  "extends": ["config:js-lib"]
 }


### PR DESCRIPTION
Meteor renovation is now enabled by default, so it is no longer necessary to explicitly enable meteor.
