### PR TITLE
Fix tests exit codes for CI

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,6 +8,7 @@ cd angular-compilers-tests
 rm -rf node_modules
 meteor npm install
 meteor npm test
+exit_code=$?; if [ ${exit_code} -gt 0 ]; then exit ${exit_code}; fi
 cd ../../examples/angularcli-meteor
 npm install
 npm run meteor-client:bundle
@@ -15,3 +16,4 @@ npm run api:reset
 export CHROME_BIN=chromium-browser
 npm run test
 concurrently "npm run start" "npm run api" "sleep 90; npm run e2e" --kill-others --success first
+exit_code=$?; if [ ${exit_code} -gt 0 ]; then exit ${exit_code}; fi


### PR DESCRIPTION
Travis was actually broken since we moved all the commands in a separate script (`run_tests.sh`), such a way the exit codes from mocha were actually hidden behind the bash script and Travis couldn't manage to pick them up. I made them propagate up to Travis.
Because of this we didn't notice that tests did actually break despite the "green flag" from Travis.
To fix them please merge https://github.com/Urigo/angular-meteor/pull/1706 together with this commit.