### PR TITLE
chore: set custom renovate branch prefix for angularcli example

### DIFF
--- a/examples/angularcli-meteor/package.json
+++ b/examples/angularcli-meteor/package.json
@@ -17,6 +17,9 @@
     "meteor-client:bundle": "meteor-client bundle -s api"
   },
   "private": true,
+  "renovate": {
+    "branchPrefix": "renovate/angularcli-"
+  },
   "dependencies": {
     "@angular/animations": "^4.2.4",
     "@angular/common": "^4.2.4",


### PR DESCRIPTION
This change will ensure that the `angularcli-meteor` example receives separate Renovate PRs from the other `package.json` files in the repository. Instead of the usual `renovate/` prefix, updates to this file will be given a `renovate/angularcli-` prefix to differentiate them, as discussed in the comments of #1732
