### PR TITLE
Install PhantomJS Ubuntu package on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - google-chrome
     packages:
       - google-chrome-stable
+      - phantomjs
 node_js:
   - "8"
 before_install:


### PR DESCRIPTION
Hello @ardatan and @Urigo,

could you merge this PR to have a phantomjs package installed on Travis CI?

Travis CI has a custom version in: /usr/local/phantomjs/bin that results in errors running
the tests with ardatan:mocha

More details are here:
https://github.com/Urigo/angular-meteor/pull/1927#issuecomment-399793547

Thanks, Georgy

