### PR TITLE
Add support for namedExports when using Rollup plugin

### DIFF
--- a/atmosphere-packages/angular-typescript-compiler/index.js
+++ b/atmosphere-packages/angular-typescript-compiler/index.js
@@ -280,8 +280,22 @@ export class AngularTsCompiler {
     console.timeEnd(`[${prefix}]: TypeScript Files Compilation`);
     if (this.isRollup && !mainCodePath.includes('node_modules')) {
       console.time(`[${prefix}]: Rollup`);
+
+      let namedExports = null;
+      const namedExportsPath = path.join(basePath, 'named-exports.json');
+      if (fs.existsSync(namedExportsPath)) {
+        try {
+          namedExports = JSON.parse(fs.readFileSync(namedExportsPath));
+        } catch (e) {
+          console.error(
+            'Error: named-exports.json does not contain valid JSON'
+          );
+          console.error(e);
+        }
+      }
+      
       const bundle = rollup(codeMap, mainCode, mainCodePath,
-        null, null, forWeb);
+        null, namedExports, forWeb);
       if (bundle) {
         // Look for a ts-file in the client or server
         // folder to add generated bundle.


### PR DESCRIPTION
Currently there is no support for namedExports when using the Rollup plugin which generates an unusable build when a 3rd party package is required and not resolved during the compilation. With this change we can allow the user to define a file called 'named-exports.json' at the root of the project and define all the namedExports required in the code.

This file could contain something like this:
```
{ './module.js': ['foo', 'bar' ] }
```

If the file does not exist, the rollup method will be passed the null value as is the current behavior.