### PR TITLE
Update compiler dependencies to most current versions

### DIFF
--- a/atmosphere-packages/angular-compilers/package.js
+++ b/atmosphere-packages/angular-compilers/package.js
@@ -14,9 +14,9 @@ Package.registerBuildPlugin({
   use: [
     // Uses an external packages to get the actual compilers
     'ecmascript@0.10.5',
-    'angular-typescript-compiler@0.3.2',
-    'angular-html-compiler@0.3.2',
-    'angular-scss-compiler@0.3.2'
+    'angular-typescript-compiler@0.3.4',
+    'angular-html-compiler@0.3.4',
+    'angular-scss-compiler@0.3.4'
   ]
 });
 


### PR DESCRIPTION
This is a quick fix to pin the required atmosphere packages to the most recent versions. Upgrade to Meteor 1.9 is otherwise not possible




