### PR TITLE
[fix] Show error upon failing to `require()`the compiler

### DIFF
--- a/atmosphere-packages/angular-compilers/plugin/register.js
+++ b/atmosphere-packages/angular-compilers/plugin/register.js
@@ -27,6 +27,7 @@ try{
     compilerCli = require('@angular/compiler-cli');
   }
 }catch(e){
+  console.error(e);
   console.log('@angular/compiler and @angular/compiler-cli must be installed for AOT compilation!');
   console.log('AOT compilation disabled!');
   console.log('Ignore this if you are using AngularJS 1.X');


### PR DESCRIPTION
I'm witnessing a resurgence of something that has the same symptoms as #1934, yet I followed all the instructions there. (See also #1988). I assume that the to-do item of https://github.com/Urigo/angular-meteor/issues/1934#issuecomment-403664875 fell through the cracks.
